### PR TITLE
FP8 quantization support for llama4

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/__init__.py
@@ -2,6 +2,7 @@
 
 from .dist import *
 from .flashinfer_attention import *
+from .flashinfer_rope import *
 from .fused_moe import *
 from .linear import *
 from .mla import *

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_rope.py
@@ -1,0 +1,63 @@
+from typing import Tuple
+
+import flashinfer
+import torch
+
+
+@torch.library.custom_op("rope::flashinfer", mutates_args=())
+def apply_rope_with_input_pos_flashinfer(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, is_neox: bool = True
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Applies rotary positional embeddings (RoPE) to query and key tensors using the FlashInfer kernel.
+
+    Inputs:
+    - q, k (torch.Tensor):
+        Tensors of shape [batch, seq_len, n_head, head_dim] or [batch, seq_len, n_head*head_dim]
+        in half precision (torch.float16 or torch.bfloat16). Note: head_dim must be a multiple of 64.
+    - cos, sin (torch.Tensor):
+        Tensors of shape [seq_len, head_dim]. For 3D Tensors, the first dimension is discarded.
+        Only the first half of the last dimension (head_dim//2 values) is used.
+        They are concatenated (cos[..., :head_dim//2] with sin[..., :head_dim//2]) to form the
+        non-interleaved cos-sin cache required by the FlashInfer kernel.
+    - is_neox (bool):
+        Flag to indicate whether to invoke the FlashInfer kernel in Neox mode.
+
+    Internal Processing:
+    - Constructs positional indices by repeating [0, seq_len) for each batch.
+    - Invokes the FlashInfer kernel with the provided `is_neox` flag.
+
+    Returns:
+    A tuple of:
+        - Rotated query tensor of shape same as input in half precision.
+        - Rotated key tensor of shape same as input in half precision.
+    """
+    cos = cos[0] if cos.dim() == 3 else cos
+    sin = sin[0] if sin.dim() == 3 else sin
+
+    q_shape = q.shape
+    k_shape = k.shape
+    batch_size, seq_len = q_shape[:2]
+    head_dim = cos.shape[-1]
+    device = q.device
+
+    q_flat = q.view(batch_size * seq_len, -1)
+    k_flat = k.view(batch_size * seq_len, -1)
+
+    positions = torch.arange(seq_len, device=device).view(1, -1).expand(batch_size, -1).flatten()
+    cos_sin_cache = torch.cat([cos[..., : head_dim // 2], sin[..., : head_dim // 2]], dim=-1)
+    cos_sin_cache = cos_sin_cache.to(torch.float32)
+
+    query_rotated_flash, key_rotated_flash = flashinfer.rope.apply_rope_with_cos_sin_cache(
+        positions, q_flat, k_flat, head_dim, cos_sin_cache, is_neox=is_neox
+    )
+    query_rotated_flash = query_rotated_flash.view(q_shape)
+    key_rotated_flash = key_rotated_flash.view(k_shape)
+    return query_rotated_flash, key_rotated_flash
+
+
+@apply_rope_with_input_pos_flashinfer.register_fake
+def apply_rope_with_input_pos_flashinfer_fake(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, is_neox: bool = True
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    return q, k

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
@@ -20,7 +20,6 @@ def apply_rotary_pos_emb(
 ):
     """
     Apply rotary positional embeddings to query and key tensors.
-
     Args:
         q: Query tensor of shape [batch, n_heads, seq_len, head_dim]
         k: Key tensor of shape [batch, n_kv_heads, seq_len, head_dim]
@@ -28,7 +27,6 @@ def apply_rotary_pos_emb(
         head_dim: Dimension of each head
         rope_theta: Base value for RoPE (default 10000.0)
         rope_scale: Scaling factor for positions (default 1.0)
-
     Returns:
         Tuple of transformed query and key tensors
     """
@@ -108,7 +106,6 @@ def fused_mha(
     rope_scale: Optional[float] = None,
 ) -> torch.Tensor:
     """Fused MHA+Rope that takes raw input from q, k, v GEMMs.
-
     Rope is performed according to the specified rope configuration. No support for caching.
     """
     # b, s info

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -237,8 +237,8 @@ class HFFactory(ModelFactory):
         except HFValidationError:
             is_hf_repo = False
         if is_hf_repo:
-            # we don't expect to use bin files in this context and they are quite large.
-            ignore_patterns = ["**pytorch_model*.bin*", "**.pt"]
+            # we don't expect to use bin files or pt/pth checkpoint files (they are quite large)
+            ignore_patterns = ["**pytorch_model*.bin*", "**.pt", "**.pth"]
             # we will also ignore the .safetensors files if we skip loading weights
             if self.skip_loading_weights:
                 ignore_patterns.append("**safetensors")

--- a/tensorrt_llm/_torch/auto_deploy/models/llama4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/llama4.py
@@ -2,6 +2,7 @@
 
 from transformers.models.llama4.modeling_llama4 import Llama4ForConditionalGeneration
 
+from ..custom_ops.attention_interface import CacheConfig
 from .factory import ModelFactoryRegistry
 from .hf import HFFactory
 
@@ -26,3 +27,8 @@ class Llama4Factory(HFFactory):
     @property
     def automodel_from_config(self):
         return self._from_config
+
+    def get_cache_config(self):
+        """Setup cache information based on quantization information."""
+        kv_cache_dtype = None
+        return CacheConfig(dtype=kv_cache_dtype)

--- a/tensorrt_llm/_torch/auto_deploy/models/llama4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/llama4.py
@@ -19,10 +19,6 @@ class Llama4Factory(HFFactory):
             "max_position_embeddings"
         ]
 
-        # TODO (lliebenwein): bug in Llama4TextAttention when attn_temperature_tuning==True
-        # disable for now...
-        self.model_kwargs["text_config"]["attn_temperature_tuning"] = False
-
     def _from_config(self, *args, **kwargs):
         kwargs.pop("trust_remote_code", None)
         return Llama4ForConditionalGeneration._from_config(*args, **kwargs)

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/__init__.py
@@ -8,6 +8,7 @@ from .fused_moe import *
 from .fusion import *
 from .kvcache import *
 from .quantization import *
+from .rope import *
 from .sharding import *
 
 try:

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/quantization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/quantization.py
@@ -9,6 +9,7 @@ from ...utils.logger import ad_logger
 from ...utils.node_utils import (
     extract_param_names_from_lin_node,
     get_quantization_params_from_linear_node,
+    is_bmm_op,
     is_linear_op,
     is_match,
 )
@@ -81,8 +82,73 @@ def _insert_quantized_linear(
     node.kwargs = {**node.kwargs, **scales}
 
 
+def _insert_quantized_bmm(
+    gm: GraphModule,
+    node: Node,
+    quantization_impl: QuantizationImpl,
+    is_quantized_graph: bool = False,
+):
+    """Replaces the bmm node with a new quantized bmm node."""
+    weight_node = node.args[1]
+
+    # Check if weight is a parameter that we need to quantize
+    if weight_node.op == "get_attr":
+        param_name = weight_node.target
+        original_weight = gm.get_parameter(param_name)
+
+        # Quantize the weight
+        new_param = nn.Parameter(
+            quantization_impl.quantize_weight(original_weight), requires_grad=False
+        )
+
+        # Update the parameter in the model
+        modname, _, attrname = param_name.rpartition(".")
+        submod = gm.get_submodule(modname)
+        setattr(submod, attrname, new_param)
+
+        def get_scale_name(scale_name):
+            return attrname + "_" + scale_name
+
+        # Register scales directly in the parent module as torch.bmm is not a module
+        for scale_name, scale in quantization_impl.default_scales(original_weight.shape).items():
+            submod.register_buffer(get_scale_name(scale_name), scale)
+
+        # Register load state dict hook
+        gm._register_load_state_dict_pre_hook(
+            partial(quantization_impl.load_hook, weight_name=param_name)
+        )
+
+        # Register load state dict hook with explicit debugging
+        # def debug_load_hook(state_dict, prefix, *args, **kwargs):
+        #     ad_logger.info(f"Debug load hook called with prefix: {prefix}")
+        #     ad_logger.info(f"State dict keys: {list(state_dict.keys())}")
+        #     ad_logger.info(f"Looking for param: {param_name}")
+        #     return quantization_impl.load_hook(
+        #         state_dict, prefix, *args, weight_name=param_name, **kwargs
+        #     )
+
+        # gm._register_load_state_dict_pre_hook(debug_load_hook)
+
+        # Change node target to quantized bmm op
+        node.target = quantization_impl.target_op()
+
+        # Insert scale nodes with proper fully qualified names
+        with gm.graph.inserting_before(node):
+            scales = {}
+            for scale_name in quantization_impl.scale_names():
+                scales[scale_name] = gm.graph.create_node(
+                    "get_attr", f"{modname}.{get_scale_name(scale_name)}"
+                )
+
+        # Update node arguments and kwargs
+        node.kwargs = {**node.kwargs, **scales}
+    else:
+        # If weight is not a parameter, we might need different handling
+        ad_logger.warning(f"BMM weight is not a parameter, skipping quantization for node {node}")
+
+
 def quantize(gm: GraphModule, quant_config: Dict[str, Any]):
-    """Quantize the GraphModule and replace linear with quantized linear."""
+    """Quantize the GraphModule and replace linear and bmm with quantized versions."""
     # extract info from quant_config
     is_quant_graph = is_quantized_graph(gm)
     quant_algo = quant_config.get("quant_algo")
@@ -93,28 +159,44 @@ def quantize(gm: GraphModule, quant_config: Dict[str, Any]):
         ad_logger.debug("No quantization to do.")
         return gm
 
-    # tracking quantized linears in the graph
-    quantized_nodes: Dict[str, int] = defaultdict(lambda: 0)
+    # tracking quantized operations in the graph
+    quantized_nodes: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
     for n in gm.graph.nodes:
         # check if we should skip this node
-        if is_match(n, skip) or not is_linear_op(n, include_quantization=False):
+        if is_match(n, skip):
             continue
 
-        # get per-layer quantization format from the node
-        quant_algo_n: str = get_quantization_from_linear_node(n) if is_quant_graph else quant_algo
-        if not quant_algo_n:
-            continue
+        # Process linear operations
+        if is_linear_op(n, include_quantization=False):
+            # get per-layer quantization format from the node
+            quant_algo_n: str = (
+                get_quantization_from_linear_node(n) if is_quant_graph else quant_algo
+            )
+            if not quant_algo_n:
+                continue
 
-        # insert quantized linear node
-        _insert_quantized_linear(gm, n, QuantizationImpl.create(quant_algo_n), is_quant_graph)
-        quantized_nodes[quant_algo_n] += 1
+            # insert quantized linear node
+            _insert_quantized_linear(gm, n, QuantizationImpl.create(quant_algo_n), is_quant_graph)
+            quantized_nodes[quant_algo_n]["linear"] += 1
+
+        # Process BMM operations
+        elif is_bmm_op(n):
+            if not quant_algo:
+                continue
+
+            # insert quantized bmm node
+            _insert_quantized_bmm(
+                gm, n, QuantizationImpl.create(quant_algo, is_bmm=True), is_quant_graph
+            )
+            quantized_nodes[quant_algo]["bmm"] += 1
 
     if is_quant_graph:
         remove_output_quantizers(gm)
 
     gm = canonicalize_graph(gm)
     for quant_algo in quantized_nodes:
-        ad_logger.info(f"Found {quantized_nodes[quant_algo]} {quant_algo} quantized nodes.")
+        for op_type, count in quantized_nodes[quant_algo].items():
+            ad_logger.info(f"Found {count} {quant_algo} quantized {op_type} nodes.")
     ad_logger.debug("After quantization: " + str(gm))
 
     return gm

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/rope.py
@@ -1,0 +1,389 @@
+import operator
+from typing import List
+
+import torch
+from torch.fx import GraphModule
+
+from ...utils.logger import ad_logger
+from ...utils.node_utils import bfs, identify_regions_between_residuals, is_op
+from .._graph import canonicalize_graph
+
+
+def match_rope_v1(gm: GraphModule) -> GraphModule:
+    """
+    Identify and replace legacy RoPE subgraphs (explicit cos/sin multiplication pattern):
+
+      output = (raw * unsqueeze(cos)) + (rotate_half(raw) * unsqueeze(sin))
+
+    If exactly two such branches (query and key) are detected within each region, they're replaced
+    by a call to `torch.ops.rope.flashinfer`.
+    """
+    graph = gm.graph
+    boundary_nodes: List[torch.fx.Node] = identify_regions_between_residuals(gm)
+
+    for start_boundary, end_boundary in zip(boundary_nodes[:-1], boundary_nodes[1:]):
+        matches = []
+        node = start_boundary
+        while node != end_boundary:
+            if is_op(node, torch.ops.aten.add):
+                match_info = _match_rotary_subpattern_V1(node)
+                if match_info:
+                    matches.append(match_info)
+            node = node.next
+
+        if not matches:
+            continue
+        if len(matches) != 2:
+            raise RuntimeError(
+                f"Expected exactly 2 legacy RoPE branches between {start_boundary} and {end_boundary}, "
+                f"found {len(matches)}."
+            )
+
+        # Assume the first matched branch is query (q), second is key (k).
+        # This assumption is based on the default ordering in the exported graph,
+        # since node naming conventions don't reliably indicate q/k branches.
+        q_match, k_match = matches
+        _process_rope_v1(graph, q_match, k_match, start_boundary)
+
+    gm = canonicalize_graph(gm)
+    return gm
+
+
+def match_rope_v2(gm: GraphModule) -> GraphModule:
+    """
+    Identify and replace RoPE subgraphs using complex multiplication pattern:
+
+      output = type_as(flatten(view_as_real(mul(view_as_complex(reshape(to_dtype(x))), unsqueeze(freqs_cis, 2)))), x)
+
+    If exactly two such branches (query and key) are detected within each region, they're replaced
+    by a call to `torch.ops.rope.flashinfer`.
+    """
+    graph = gm.graph
+    boundary_nodes: List[torch.fx.Node] = identify_regions_between_residuals(gm)
+
+    for start_boundary, end_boundary in zip(boundary_nodes[:-1], boundary_nodes[1:]):
+        matches = []
+        node = start_boundary
+        while node != end_boundary:
+            if is_op(node, torch.ops.aten.type_as):
+                match_info = _match_rotary_subpattern_V2(node)
+                if match_info:
+                    matches.append(match_info)
+            node = node.next
+
+        if not matches:
+            continue
+        if len(matches) != 2:
+            raise RuntimeError(
+                f"Expected exactly 2 complex RoPE branches between {start_boundary} and {end_boundary}, "
+                f"found {len(matches)}."
+            )
+
+        # Assume the first matched branch is query (q), second is key (k).
+        # This assumption is based on the default ordering in the exported graph,
+        # since node naming conventions don't reliably indicate q/k branches.
+        q_match, k_match = matches
+        _process_rope_v2(graph, q_match, k_match, start_boundary)
+
+    gm = canonicalize_graph(gm)
+    return gm
+
+
+def _match_rotary_subpattern_V1(add_node):
+    """
+    Given an aten.add.Tensor node that is expected to compute:
+      output = (raw_input * unsqueeze(cos)) + (rotate_half(raw_input) * unsqueeze(sin))
+    where rotate_half is implemented as:
+      rotate_half(x) = cat([ -slice(x, second_half), slice(x, first_half) ], dim=-1)
+    this function inspects the structure of add_node and returns a dictionary with:
+       - "raw_input": the original q/k tensor,
+       - "unsqueeze_cos": the unsqueeze node feeding the raw multiplication,
+       - "unsqueeze_sin": the unsqueeze node feeding the rotated multiplication,
+       - "add_node": the addition node itself.
+    Returns None if the pattern does not match.
+    """
+    # Check that add_node is an add operation with two inputs.
+    if not is_op(add_node, torch.ops.aten.add):
+        return None
+    if not (len(add_node.args) == 2):
+        return None
+
+    mul1, mul2 = add_node.args
+    # Both inputs to the add should be multiplications.
+    if not is_op(mul1, torch.ops.aten.mul):
+        return None
+    if not is_op(mul2, torch.ops.aten.mul):
+        return None
+
+    # One branch should be the raw branch and the other the rotated branch.
+    # We decide by checking if one multiplication’s first argument is a cat (i.e. the rotate_half result).
+    if is_op(mul1.args[0], torch.ops.aten.cat):
+        mul_rot = mul1
+        mul_raw = mul2
+    elif is_op(mul2.args[0], torch.ops.aten.cat):
+        mul_rot = mul2
+        mul_raw = mul1
+    else:
+        return None
+
+    # Verify that both multiplications have an unsqueeze as their second argument.
+    unsqueeze_cos = mul_raw.args[1]
+    unsqueeze_sin = mul_rot.args[1]
+    if not is_op(unsqueeze_cos, torch.ops.aten.unsqueeze):
+        return None
+    if not is_op(unsqueeze_sin, torch.ops.aten.unsqueeze):
+        return None
+
+    # Check that the rotated branch is a cat of two tensors along -1.
+    cat_node = mul_rot.args[0]
+    if not is_op(cat_node, torch.ops.aten.cat):
+        return None
+    # Expecting two inputs in a list/tuple.
+    cat_inputs = cat_node.args[0]
+    if not (isinstance(cat_inputs, (list, tuple)) and len(cat_inputs) == 2):
+        return None
+
+    # One of the two inputs should be a negation of a slice, the other should be a slice.
+    first_item, second_item = cat_inputs
+    if not is_op(first_item, torch.ops.aten.neg):
+        return None
+    if not is_op(second_item, torch.ops.aten.slice):
+        return None
+
+    # The negation node should wrap a slice.
+    neg_node = first_item
+    if not (len(neg_node.args) >= 1 and is_op(neg_node.args[0], torch.ops.aten.slice)):
+        return None
+
+    # For simplicity, require that the two slice operations (the one inside neg and the one used directly)
+    # are applied on the same original tensor. This original tensor is the one being rotated.
+    slice_in_neg = neg_node.args[0]
+    if slice_in_neg.args[0] != second_item.args[0]:
+        return None
+
+    # Finally, the raw branch should multiply the original tensor (i.e. q or k) by unsqueeze_cos.
+    raw_input = mul_raw.args[0]
+    # We also expect that the tensor being sliced (and negated) is the same as raw_input.
+    if raw_input != slice_in_neg.args[0]:
+        return None
+
+    return {
+        "raw_input": raw_input,
+        "unsqueeze_cos": unsqueeze_cos,
+        "unsqueeze_sin": unsqueeze_sin,
+        "add_node": add_node,
+    }
+
+
+def _match_rotary_subpattern_V2(type_as_node):
+    """
+    Given a type_as node, this function inspects the graph
+    structure and returns a dictionary with:
+       - "input": the original xq (or xk) tensor,
+       - "inv_freq": the freqs_cis tensor (before unsqueeze),
+       - "out": the type_as node corresponding to the branch output.
+
+    Expected branch structure for each output:
+        x_out = type_as( flatten( view_as_real( view_as_complex(reshape(to_dtype(x))) * unsqueeze(freqs_cis) ) ) )
+
+    Returns None if the structure does not match.
+    """
+    if not is_op(type_as_node, torch.ops.aten.type_as):
+        return None
+
+    # The type_as node should have at least one argument: its first argument is the flatten op.
+    if not (len(type_as_node.args) >= 1):
+        return None
+    flatten_node = type_as_node.args[0]
+    if not is_op(flatten_node, torch.ops.aten.flatten):
+        return None
+
+    # The input of the flatten op should be a view_as_real op.
+    if not (len(flatten_node.args) >= 1):
+        return None
+    view_as_real_node = flatten_node.args[0]
+    if not is_op(view_as_real_node, torch.ops.aten.view_as_real):
+        return None
+
+    # The input of view_as_real should be a multiplication.
+    if not (len(view_as_real_node.args) >= 1):
+        return None
+    mul_node = view_as_real_node.args[0]
+    if not is_op(mul_node, torch.ops.aten.mul):
+        return None
+    if len(mul_node.args) != 2:
+        return None
+
+    # In the multiplication, one operand should be an unsqueeze of freqs_cis and
+    #    the other operand is the output of view_as_complex.
+    if is_op(mul_node.args[0], torch.ops.aten.unsqueeze):
+        unsqueeze_node = mul_node.args[0]
+        vc_node = mul_node.args[1]
+    elif is_op(mul_node.args[1], torch.ops.aten.unsqueeze):
+        unsqueeze_node = mul_node.args[1]
+        vc_node = mul_node.args[0]
+    else:
+        return None
+
+    # Verify that the unsqueeze is performed along dimension 2.
+    if not (len(unsqueeze_node.args) >= 2 and unsqueeze_node.args[1] == 2):
+        return None
+    inv_freq_candidate = unsqueeze_node.args[0]
+
+    # Match the view_as_complex branch.
+    if not is_op(vc_node, torch.ops.aten.view_as_complex):
+        return None
+    if not (len(vc_node.args) >= 1):
+        return None
+    reshape_node = vc_node.args[0]
+    if not is_op(reshape_node, torch.ops.aten.reshape):
+        return None
+
+    # The reshape op should get its input from a to(dtype) conversion.
+    if not (len(reshape_node.args) >= 1):
+        return None
+    to_node = reshape_node.args[0]
+    if not is_op(to_node, torch.ops.aten.to):
+        return None
+    if not (len(to_node.args) >= 1):
+        return None
+    input_tensor = to_node.args[0]
+
+    return {
+        "input": input_tensor,
+        "inv_freq": inv_freq_candidate,
+        "out": type_as_node,
+    }
+
+
+def _process_rope_v1(graph, q_match, k_match, start_boundary):
+    """
+    Process a region that matched the legacy RoPE pattern (v1).
+    Inserts the custom op (flashinfer) and replaces the original add nodes.
+    """
+    q_node = q_match["raw_input"]
+    k_node = k_match["raw_input"]
+    cos_node = q_match["unsqueeze_cos"].args[0]
+    sin_node = q_match["unsqueeze_sin"].args[0]
+
+    # Sanity-check: ensure cos/sin nodes trace back to aten.cos/aten.sin.
+    bfs(
+        cos_node,
+        lambda n: is_op(n, torch.ops.aten.cos),
+        attr_next="all_input_nodes",
+        boundary=start_boundary,
+    )
+    bfs(
+        sin_node,
+        lambda n: is_op(n, torch.ops.aten.sin),
+        attr_next="all_input_nodes",
+        boundary=start_boundary,
+    )
+
+    # Infer input layout; default to [b, n, s, d] if inference fails.
+    q_fake = q_node.meta.get("val", None)
+    if q_fake is not None and len(q_fake.shape) > 2:
+        need_transpose = isinstance(q_fake.shape[1], int)
+        ad_logger.debug(
+            f"Inferred RoPE input layout: [{'[b, n, s, d]' if need_transpose else '[b, s, n, d]'}]"
+        )
+        # Additional sanity check for the third dimension
+        if need_transpose:
+            if not isinstance(q_fake.shape[2], torch.SymInt):
+                ad_logger.warning(
+                    "Sanity check failed: q_fake.shape[2] should be symbolic. Defaulting to [b, n, s, d]"
+                )
+                need_transpose = True
+        else:
+            if not isinstance(q_fake.shape[1], torch.SymInt):
+                ad_logger.warning(
+                    "Sanity check failed: q_fake.shape[2] should be symbolic. Defaulting to [b, n, s, d]"
+                )
+                need_transpose = True
+    else:
+        ad_logger.warning("Unable to infer layout of q node. Defaulting to [b, n, s, d].")
+        need_transpose = True
+
+    with graph.inserting_before(q_match["add_node"]):
+        if need_transpose:
+            q_for_op = graph.call_function(torch.ops.aten.transpose, args=(q_node, 1, 2))
+            k_for_op = graph.call_function(torch.ops.aten.transpose, args=(k_node, 1, 2))
+            q_for_op_contig = graph.call_method("contiguous", (q_for_op,))
+            k_for_op_contig = graph.call_method("contiguous", (k_for_op,))
+        else:
+            q_for_op_contig, k_for_op_contig = q_node, k_node
+
+        flash_node = graph.call_function(
+            torch.ops.rope.flashinfer,
+            args=(q_for_op_contig, k_for_op_contig, cos_node, sin_node, True),
+        )
+
+    with graph.inserting_after(flash_node):
+        raw_q = graph.call_function(operator.getitem, args=(flash_node, 0))
+        raw_k = graph.call_function(operator.getitem, args=(flash_node, 1))
+
+    if need_transpose:
+        with graph.inserting_after(raw_q):
+            new_q = graph.call_function(torch.ops.aten.transpose, args=(raw_q, 1, 2))
+        with graph.inserting_after(raw_k):
+            new_k = graph.call_function(torch.ops.aten.transpose, args=(raw_k, 1, 2))
+    else:
+        new_q, new_k = raw_q, raw_k
+
+    new_q.meta["val"] = q_match["add_node"].meta["val"]
+    new_k.meta["val"] = k_match["add_node"].meta["val"]
+
+    q_match["add_node"].replace_all_uses_with(new_q)
+    k_match["add_node"].replace_all_uses_with(new_k)
+
+
+def _process_rope_v2(graph, q_match, k_match, start_boundary):
+    """
+    Process a region that matched the complex-multiplication RoPE pattern (v2).
+    Inserts the custom op (flashinfer) after extracting frequency info and replaces
+    the original type_as nodes.
+    """
+    q_node = q_match["input"]
+    k_node = k_match["input"]
+    inv_freq_node = q_match["inv_freq"]
+
+    if inv_freq_node != k_match["inv_freq"]:
+        raise RuntimeError("Mismatch of freqs_cis (inv_freq) between branches.")
+
+    # Sanity check that input layout is BSND (no transpose needed).
+    q_fake = q_node.meta.get("val", None)
+    if q_fake is not None and len(q_fake.shape) > 2:
+        if not (isinstance(q_fake.shape[1], torch.SymInt) and isinstance(q_fake.shape[2], int)):
+            ad_logger.warning(
+                f"""Sanity check failed: q_fake should have shape [b, s, n, d],
+                s should be symbolic and n should be int, instead got shape {q_fake.shape}"""
+            )
+    else:
+        ad_logger.warning(
+            f"Sanity check failed: q_fake should be 3D or 4D, but got shape {q_fake.shape}"
+        )
+
+    with graph.inserting_before(q_match["out"]):
+        q_for_op_contig, k_for_op_contig = q_node, k_node
+        cos_from_freqs = graph.call_function(torch.ops.aten.real, args=(inv_freq_node,))
+        sin_from_freqs = graph.call_function(torch.ops.aten.imag, args=(inv_freq_node,))
+        cos_flash = graph.call_function(
+            torch.ops.aten.cat, args=((cos_from_freqs, cos_from_freqs), -1)
+        )
+        sin_flash = graph.call_function(
+            torch.ops.aten.cat, args=((sin_from_freqs, sin_from_freqs), -1)
+        )
+        flash_node = graph.call_function(
+            torch.ops.rope.flashinfer,
+            args=(q_for_op_contig, k_for_op_contig, cos_flash, sin_flash, False),
+        )
+
+    with graph.inserting_after(flash_node):
+        raw_q = graph.call_function(operator.getitem, args=(flash_node, 0))
+        raw_k = graph.call_function(operator.getitem, args=(flash_node, 1))
+
+    raw_q.meta["val"] = q_match["out"].meta["val"]
+    raw_k.meta["val"] = k_match["out"].meta["val"]
+
+    q_match["out"].replace_all_uses_with(raw_q)
+    k_match["out"].replace_all_uses_with(raw_k)

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/sdpa.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/sdpa.py
@@ -79,9 +79,9 @@ def _insert_transposes(egm: GraphModule, attention_nodes: List[Node]) -> GraphMo
 
         # Create transpose nodes before the attention node
         with graph.inserting_before(attn_node):
-            q_transposed = graph.call_function(torch.transpose, args=(q, 1, 2))
-            k_transposed = graph.call_function(torch.transpose, args=(k, 1, 2))
-            v_transposed = graph.call_function(torch.transpose, args=(v, 1, 2))
+            q_transposed = graph.call_function(torch.ops.aten.transpose.int, args=(q, 1, 2))
+            k_transposed = graph.call_function(torch.ops.aten.transpose.int, args=(k, 1, 2))
+            v_transposed = graph.call_function(torch.ops.aten.transpose.int, args=(v, 1, 2))
 
         # Replace the q, k, v inputs with their transposed versions
         new_args = (q_transposed, k_transposed, v_transposed) + attn_node.args[3:]

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -24,6 +24,8 @@ from .library import (
     fuse_gemms,
     fuse_moe,
     match_moe_pattern,
+    match_rope_v1,
+    match_rope_v2,
     quantize,
     resize_kv_cache,
 )
@@ -94,6 +96,10 @@ class InferenceOptimizer:
 
         # Match MoE pattern
         egm = match_moe_pattern(egm)
+
+        # Match Rope pattern
+        egm = match_rope_v1(egm)
+        egm = match_rope_v2(egm)
 
         ############################################################################################
         # RUN TRANSFORMATIONS ON STANDARDIZED GRAPH REPRESENTATION

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -7,7 +7,7 @@ import torch
 from torch._ops import OpOverload, OpOverloadPacket
 from torch.fx import Graph, GraphModule, Node
 
-from ..custom_ops.quant import QUANT_OPS
+from ..custom_ops.quant import QUANT_BMM_OPS, QUANT_LINEAR_OPS
 from .logger import ad_logger
 
 try:
@@ -207,8 +207,18 @@ def is_linear_op(node: Node, include_quantization: bool = False) -> bool:
     }
 
     if include_quantization:
-        lin_ops.update(QUANT_OPS)
+        lin_ops.update(QUANT_LINEAR_OPS)
     return is_op(node, lin_ops)
+
+
+def is_bmm_op(node: Node, include_quantization: bool = False) -> bool:
+    """Check if the node is a distributed op."""
+    dist_ops = {torch.ops.aten.bmm}
+
+    if include_quantization:
+        dist_ops.update(QUANT_BMM_OPS)
+
+    return is_op(node, dist_ops)
 
 
 def is_dist_op(node: Node) -> bool:

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -178,6 +178,9 @@ def get_op_overload_packet(node: Union[OpOverloadPacket, OpOverload]) -> OpOverl
 
 def is_op(node: Node, ops: Union[OpOverloadPacket, Iterable[OpOverloadPacket]]) -> bool:
     """Check if the node is a call to one of the ops."""
+    if not isinstance(node, Node):
+        return False
+
     if node.op != "call_function":
         return False
 
@@ -284,7 +287,8 @@ def identify_regions_between_residuals(gm: GraphModule) -> List[Node]:
     # TODO: seems to come from post_attention_layer_norm that is *only* applied to the input to the
     # MLP layer but not to the residual. Hence, the "add" has multiple users.
     res_nodes_more_users = [n for n in boundary_nodes[2:] if len(n.users) > 2]
-    ad_logger.warning(f"Unexpected # of users for residuals: {res_nodes_more_users}")
+    if res_nodes_more_users:
+        ad_logger.warning(f"Unexpected # of users for residuals: {res_nodes_more_users}")
 
     # add output node to boundary nodes
     boundary_nodes.append(output_node)

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -1,7 +1,7 @@
 """Common utils for torch fx graph transformation."""
 
 from dataclasses import dataclass
-from typing import Iterable, List, Optional, Tuple, Union
+from typing import Callable, Iterable, List, Optional, Tuple, Union
 
 import torch
 from torch._ops import OpOverload, OpOverloadPacket
@@ -290,3 +290,23 @@ def identify_regions_between_residuals(gm: GraphModule) -> List[Node]:
     boundary_nodes.append(output_node)
 
     return boundary_nodes
+
+
+def bfs(
+    node: Node, target: Callable, attr_next: str = "users", boundary: Optional[Node] = None
+) -> Node:
+    queue = [node]
+    visited = set()
+    while queue:
+        cur_node = queue.pop(0)
+        if boundary is not None and cur_node == boundary:
+            continue  # Skip the boundary node.
+        if target(cur_node):
+            return cur_node
+        for next_node in getattr(cur_node, attr_next):
+            if boundary is not None and next_node == boundary:
+                continue  # Do not expand past the boundary.
+            if next_node not in visited:
+                visited.add(next_node)
+                queue.append(next_node)
+    raise RuntimeError(f"Could not find node with target condition {target}.")

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_graph_test_helpers.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_graph_test_helpers.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Callable, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import numpy as np
 import torch
@@ -34,6 +34,7 @@ def run_test(
     rtol: float = 1e-3,
     test_load_hook: bool = True,
     strict_loading: bool = True,
+    dynamic_shapes: Dict = None,
     *args,  # Additional arguments for transform
 ) -> GraphModule:
     # run model once
@@ -44,7 +45,7 @@ def run_test(
     print(num_params_model)
 
     # export + check (we clone the state dict to have a bit more freedom in testing below)
-    gm = torch_export_to_gm(model, args=(x,), clone=True)
+    gm = torch_export_to_gm(model, args=(x,), dynamic_shapes=(dynamic_shapes,), clone=True)
     print(gm)
     y_gm = gm(x)
     num_params_gm = count_parameters(gm)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_hf_flashinfer_rope.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_hf_flashinfer_rope.py
@@ -1,0 +1,145 @@
+from typing import Tuple
+
+import flashinfer
+import pytest
+import torch
+
+import tensorrt_llm._torch.auto_deploy  # noqa: F401
+
+torch.manual_seed(0)
+
+
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+# Copied from transformers.models.llama.modeling_llama.apply_rotary_pos_emb
+def apply_rotary_pos_emb(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, unsqueeze_dim: int = 1
+):
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+@pytest.mark.parametrize("head_dim", [64, 256])  # head_dim must be a multiple of 64
+@pytest.mark.parametrize(
+    "dtype,atol,rtol",
+    [
+        (torch.bfloat16, 1e-4, 1e-4),
+        (torch.float16, 5e-4, 5e-4),
+    ],
+    ids=["bfloat16", "float16"],  # q/k must be in half precision
+)
+def test_flashinfer_and_custom_rope_ops(dtype, atol, rtol, head_dim):
+    device = "cuda"
+    batch = 2
+    seq_len = 4
+    n_head = 3
+
+    # Prepare rotary embedding values.
+    inv_freq = 1.0 / (
+        10000
+        ** (torch.arange(0, head_dim // 2, dtype=torch.float32, device=device) / (head_dim // 2))
+    )
+    positions_range = torch.arange(seq_len, dtype=torch.float32, device=device)
+    angles = positions_range.unsqueeze(1) * inv_freq.unsqueeze(0)  # [seq_len, head_dim//2]
+    cos_vals = torch.cos(angles)  # [seq_len, head_dim//2]
+    sin_vals = torch.sin(angles)  # [seq_len, head_dim//2]
+
+    # For direct FlashInfer call: non-interleaved cache [seq_len, head_dim] (concatenated).
+    cos_sin_cache = torch.cat([cos_vals, sin_vals], dim=1)
+    # For HF and the custom op: duplicated layout [seq_len, head_dim].
+    cos_new = torch.cat([cos_vals, cos_vals], dim=-1)
+    sin_new = torch.cat([sin_vals, sin_vals], dim=-1)
+
+    query = torch.randn(batch, seq_len, n_head, head_dim, dtype=dtype, device=device)
+    key = torch.randn(batch, seq_len, n_head, head_dim, dtype=dtype, device=device)
+
+    # Direct FlashInfer kernel call.
+    query_flat = query.view(batch * seq_len, n_head * head_dim)
+    key_flat = key.view(batch * seq_len, n_head * head_dim)
+    positions = torch.cat([torch.arange(seq_len, device=device) for _ in range(batch)])
+    q_flash, k_flash = flashinfer.rope.apply_rope_with_cos_sin_cache(
+        positions, query_flat, key_flat, head_dim, cos_sin_cache, is_neox=True
+    )
+    q_flash = q_flash.view(batch, seq_len, n_head, head_dim)
+    k_flash = k_flash.view(batch, seq_len, n_head, head_dim)
+
+    # HF implementation using apply_rotary_pos_emb.
+    # HF expects [batch, n_head, seq_len, head_dim] for unsqueeze_dim=1
+    q_for_hf = query.transpose(1, 2).clone()
+    k_for_hf = key.transpose(1, 2).clone()
+    cos_expand = cos_new.unsqueeze(0).expand(batch, -1, -1)  # [batch, seq_len, head_dim]
+    sin_expand = sin_new.unsqueeze(0).expand(batch, -1, -1)  # [batch, seq_len, head_dim]
+    q_hf, k_hf = apply_rotary_pos_emb(q_for_hf, k_for_hf, cos_expand, sin_expand, unsqueeze_dim=1)
+
+    # Convert outputs to [batch, seq_len, n_head, head_dim]
+    q_hf = q_hf.transpose(1, 2).to(dtype)
+    k_hf = k_hf.transpose(1, 2).to(dtype)
+
+    # Custom op call
+    custom_q, custom_k = torch.ops.rope.flashinfer(query, key, cos_new, sin_new, True)
+
+    torch.testing.assert_close(q_hf, q_flash, rtol=rtol, atol=atol)
+    torch.testing.assert_close(k_hf, k_flash, rtol=rtol, atol=atol)
+    torch.testing.assert_close(q_hf, custom_q, rtol=rtol, atol=atol)
+    torch.testing.assert_close(k_hf, custom_k, rtol=rtol, atol=atol)
+
+
+# Version 2: complex multiplication approach
+def apply_rotary_emb(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    freqs_cis: torch.Tensor,  # Expected shape: (B, seq, head_dim//2)
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
+    xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
+    xq_out = torch.view_as_real(xq_ * freqs_cis[:, :, None, :]).flatten(3)
+    xk_out = torch.view_as_real(xk_ * freqs_cis[:, :, None, :]).flatten(3)
+    return xq_out.type_as(xq), xk_out.type_as(xk)
+
+
+@pytest.mark.parametrize("head_dim", [64, 256])  # Must be a multiple of 64
+@pytest.mark.parametrize(
+    "dtype,atol,rtol",
+    [
+        (torch.bfloat16, 1e-5, 1e-5),
+        (torch.float16, 5e-4, 5e-4),
+    ],
+    ids=["bfloat16", "float16"],  # q/k must be in half precision
+)
+def test_flashinfer_complex_rotary(dtype, atol, rtol, head_dim):
+    device = "cuda"
+    batch = 2
+    seq_len = 4
+    n_head = 3
+
+    inv_freq = 1.0 / (
+        10000
+        ** (torch.arange(0, head_dim // 2, dtype=torch.float32, device=device) / (head_dim // 2))
+    )
+    positions_range = torch.arange(seq_len, dtype=torch.float32, device=device)
+    angles = positions_range.unsqueeze(1) * inv_freq.unsqueeze(0)  # shape: (seq_len, head_dim//2)
+    freqs_cis = torch.polar(torch.ones((seq_len, head_dim // 2), device=device), angles)
+    freqs_cis = freqs_cis.unsqueeze(0).expand(batch, -1, -1)  # shape: (B, seq, head_dim//2)
+
+    query = torch.randn(batch, seq_len, n_head, head_dim, dtype=dtype, device=device)
+    key = torch.randn(batch, seq_len, n_head, head_dim, dtype=dtype, device=device)
+
+    out_q_v2, out_k_v2 = apply_rotary_emb(query, key, freqs_cis)
+
+    cos_from_freqs = torch.real(freqs_cis)  # (B, seq, head_dim//2)
+    sin_from_freqs = torch.imag(freqs_cis)  # (B, seq, head_dim//2)
+    cos_flash = torch.cat((cos_from_freqs, cos_from_freqs), dim=-1)  # (B, seq, head_dim)
+    sin_flash = torch.cat((sin_from_freqs, sin_from_freqs), dim=-1)  # (B, seq, head_dim)
+
+    # q/k of llama4 rope is interleaved
+    custom_q, custom_k = torch.ops.rope.flashinfer(query, key, cos_flash, sin_flash, False)
+
+    torch.testing.assert_close(out_q_v2, custom_q, rtol=rtol, atol=atol)
+    torch.testing.assert_close(out_k_v2, custom_k, rtol=rtol, atol=atol)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rope_matcher.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rope_matcher.py
@@ -1,0 +1,188 @@
+import pytest
+import torch
+from _graph_test_helpers import run_test
+from torch.export import Dim
+
+from tensorrt_llm._torch.auto_deploy.transformations.library.rope import (
+    match_rope_v1,
+    match_rope_v2,
+)
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+
+torch.manual_seed(0)
+
+
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, unsqueeze_dim: int = 1
+):
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def _precompute_freqs_cis(seq_len: int, head_dim: int, rope_theta: float):
+    dtype = torch.float32
+    inv_freq = 1.0 / (rope_theta ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim))
+    positions = torch.arange(seq_len, dtype=torch.float32)
+    freqs = positions.unsqueeze(1) * inv_freq.unsqueeze(0)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    cos = emb.cos().to(dtype)
+    sin = emb.sin().to(dtype)
+    return cos, sin
+
+
+def apply_rotary_emb(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    freqs_cis: torch.Tensor,  # Expected shape: (B, seq, head_dim//2) and complex dtype.
+):
+    # Reshape the inputs to pair the last dimension.
+    xq_complex = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
+    xk_complex = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
+    # Multiply with frequencies. Note that freqs_cis is expected to broadcast with an extra head dim.
+    xq_out = torch.view_as_real(xq_complex * freqs_cis[:, :, None, :]).flatten(3)
+    xk_out = torch.view_as_real(xk_complex * freqs_cis[:, :, None, :]).flatten(3)
+    return xq_out.type_as(xq), xk_out.type_as(xk)
+
+
+def _precompute_freqs_cis_v2(seq_len: int, head_dim: int, rope_theta: float):
+    """
+    Compute the frequency tensor for the complex multiplication RoPE variant.
+    Returns a complex tensor of shape (seq_len, head_dim//2).
+    """
+    inv_freq = 1.0 / (
+        rope_theta ** (torch.arange(0, head_dim // 2, dtype=torch.float32) / (head_dim // 2))
+    )
+    positions = torch.arange(seq_len, dtype=torch.float32)
+    angles = positions.unsqueeze(1) * inv_freq.unsqueeze(0)  # (seq_len, head_dim//2)
+    # Create a complex tensor from magnitude=1 and the computed angles.
+    freqs_cis = torch.polar(torch.ones_like(angles), angles)
+    return freqs_cis
+
+
+class RotaryModel(torch.nn.Module):
+    def __init__(self, hidden_size: int, max_seq_len: int, layout: str = "BNSD"):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.max_seq_len = max_seq_len
+        self.layout = layout
+        self.linear = torch.nn.Linear(hidden_size, hidden_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        q = self.linear(x)
+        k = self.linear(x)
+        # Simulate a single-head scenario by unsqueezing the head dimension.
+        q = q.unsqueeze(1)
+        k = k.unsqueeze(1)  # [B, 1, S, D]
+        batch, _, seq, hidden = q.shape
+        if self.layout == "BSND":
+            # Transpose to [B, S, N, D]
+            q = q.transpose(1, 2).contiguous()
+            k = k.transpose(1, 2).contiguous()
+            unsqueeze_dim = 2
+        else:
+            # For BNSD, layout remains [B, N, S, D]
+            unsqueeze_dim = 1
+
+        # Precompute cosine-sine cache. shape: [max_seq_len, hidden].
+        cos, sin = _precompute_freqs_cis(seq, hidden, rope_theta=10000)
+        cos = cos.to(q.device)
+        sin = sin.to(q.device)
+        cos = cos.unsqueeze(0).expand(batch, -1, -1)  # [B, max_seq_len, hidden]
+        sin = sin.unsqueeze(0).expand(batch, -1, -1)
+
+        q_embed, k_embed = apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=unsqueeze_dim)
+        return (q_embed + k_embed).to(torch.float16)
+
+    def get_dynamic_shapes(self):
+        return {0: Dim("batch_size", max=8), 1: Dim("seq_len", max=16)}
+
+
+class RotaryModelV2(torch.nn.Module):
+    def __init__(self, hidden_size: int, max_seq_len: int):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.max_seq_len = max_seq_len
+        self.linear = torch.nn.Linear(hidden_size, hidden_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        q = self.linear(x)
+        k = self.linear(x)
+        q = q.unsqueeze(2)
+        k = k.unsqueeze(2)  # [B, S, 1, D]
+        batch, seq, n_head, hidden = q.shape
+
+        # Precompute the complex frequency tensor.
+        freqs_cis = _precompute_freqs_cis_v2(seq, hidden, rope_theta=10000)
+        freqs_cis = freqs_cis.to(q.device)  # [seq, hidden//2]
+        # Expand to batch dimension; expected shape: [B, seq, hidden//2]
+        freqs_cis = freqs_cis.unsqueeze(0).expand(batch, -1, -1)
+
+        q_embed, k_embed = apply_rotary_emb(q, k, freqs_cis)
+        out = (q_embed + k_embed).to(torch.float16)
+        return out
+
+    def get_dynamic_shapes(self):
+        return {0: Dim("batch_size", max=8), 1: Dim("seq_len", max=16)}
+
+
+@pytest.mark.parametrize(
+    "layout",
+    ["BNSD", "BSND"],
+)
+@torch.inference_mode()
+def test_match_rope(layout):
+    batch_size, seq_len = 8, 16
+    hidden_size = 64
+    max_position_embeddings = seq_len
+
+    model = RotaryModel(hidden_size, max_position_embeddings, layout=layout).to(
+        "cuda", dtype=torch.float16
+    )
+    x = torch.randn(batch_size, seq_len, hidden_size, device="cuda", dtype=torch.float16)
+    dynamic_shapes = model.get_dynamic_shapes()
+
+    _ = run_test(
+        model,
+        x,
+        match_rope_v1,
+        lambda gm: any(is_op(n, torch.ops.rope.flashinfer) for n in gm.graph.nodes),
+        lambda num_p_og: num_p_og,
+        atol=1e-3,
+        rtol=1e-3,
+        test_load_hook=True,
+        strict_loading=True,
+        dynamic_shapes=dynamic_shapes,
+    )
+
+
+@torch.inference_mode()
+def test_match_rope_v2():
+    batch_size, seq_len = 8, 16
+    hidden_size = 64
+    max_position_embeddings = seq_len
+
+    model = RotaryModelV2(hidden_size, max_position_embeddings).to("cuda", dtype=torch.float16)
+    x = torch.randn(batch_size, seq_len, hidden_size, device="cuda", dtype=torch.float16)
+    dynamic_shapes = model.get_dynamic_shapes()
+
+    _ = run_test(
+        model,
+        x,
+        match_rope_v2,
+        lambda gm: any(is_op(n, torch.ops.rope.flashinfer) for n in gm.graph.nodes),
+        lambda num_p_og: num_p_og,
+        atol=1e-3,
+        rtol=1e-3,
+        test_load_hook=True,
+        strict_loading=True,
+        dynamic_shapes=dynamic_shapes,
+    )


### PR DESCRIPTION
* Add FP8 and FP4 bmm ops
* Support quantization transformation for bmm
* Unit tests
    * FP8/FP4 ops
    * FP8 quantization transformation.


Testing: python build_and_run_ad.py --config '{"model_factory": "hf-llama4", "batch_size": 8, "page_size": 16, "world_size": 4, "runtime": "demollm", "compile_backend": "torch-simple", "attn_backend": "UnfusedTritonWithFlattenedInputs", "model": "/home/scratch.omniml_data_2/weimingc/Llama-4-Scout-17B-16E-Instruct_fp8_hf_AD", "benchmark": false, "skip_loading_weights": false}' --model-kwargs '{}'