### PR TITLE
[AutoDeploy] Make all ranks agree on kv-cache size

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
@@ -228,7 +228,11 @@ def insert_mla_with_kv_cache(
 
 
 def resize_kv_cache(
-    egm: GraphModule, cm: CachedSequenceInterface, free_mem_ratio: float = 0.8
+    egm: GraphModule, 
+    cm: CachedSequenceInterface, 
+    local_rank, 
+    world_size, 
+    free_mem_ratio: float = 0.8, 
 ) -> None:
     """Inflate the kv cache to occupy the available GPU memory.
 
@@ -256,6 +260,13 @@ def resize_kv_cache(
 
         new_cache_size = free_mem_post * free_mem_ratio + current_cache_size
         new_num_pages = int(new_cache_size // (current_cache_size // current_num_pages))
+        # Need to sync all the GPUs
+#        if world_size > 1:
+        gathered_pages = [None] * world_size
+        torch.distributed.all_gather_object(gathered_pages, new_num_pages)
+        new_num_pages = min(gathered_pages)
+        ad_logger.info(f"After all_gather - new_num_pages: {new_num_pages}")
+    
         ad_logger.info(f"New cache size: {new_cache_size}, New num pages: {new_num_pages}")
         cm.resize_cache(new_num_pages)
     except Exception as e:

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
@@ -228,10 +228,10 @@ def insert_mla_with_kv_cache(
 
 
 def resize_kv_cache(
-    egm: GraphModule, 
-    cm: CachedSequenceInterface, 
-    world_size: int, 
-    free_mem_ratio: float = 0.8, 
+    egm: GraphModule,
+    cm: CachedSequenceInterface,
+    world_size: int,
+    free_mem_ratio: float = 0.8,
 ) -> None:
     """Inflate the kv cache to occupy the available GPU memory.
 
@@ -259,13 +259,13 @@ def resize_kv_cache(
 
         new_cache_size = free_mem_post * free_mem_ratio + current_cache_size
         new_num_pages = int(new_cache_size // (current_cache_size // current_num_pages))
-        
+
         # Need to sync all the GPUs
         gathered_pages = [None] * world_size
         torch.distributed.all_gather_object(gathered_pages, new_num_pages)
         new_num_pages = min(gathered_pages)
         ad_logger.info(f"After all_gather - new_num_pages: {new_num_pages}")
-    
+
         cm.resize_cache(new_num_pages)
     except Exception as e:
         ad_logger.warning(

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
@@ -230,8 +230,7 @@ def insert_mla_with_kv_cache(
 def resize_kv_cache(
     egm: GraphModule, 
     cm: CachedSequenceInterface, 
-    local_rank, 
-    world_size, 
+    world_size: int, 
     free_mem_ratio: float = 0.8, 
 ) -> None:
     """Inflate the kv cache to occupy the available GPU memory.

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
@@ -260,14 +260,13 @@ def resize_kv_cache(
 
         new_cache_size = free_mem_post * free_mem_ratio + current_cache_size
         new_num_pages = int(new_cache_size // (current_cache_size // current_num_pages))
+        
         # Need to sync all the GPUs
-#        if world_size > 1:
         gathered_pages = [None] * world_size
         torch.distributed.all_gather_object(gathered_pages, new_num_pages)
         new_num_pages = min(gathered_pages)
         ad_logger.info(f"After all_gather - new_num_pages: {new_num_pages}")
     
-        ad_logger.info(f"New cache size: {new_cache_size}, New num pages: {new_num_pages}")
         cm.resize_cache(new_num_pages)
     except Exception as e:
         ad_logger.warning(

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -163,7 +163,7 @@ class InferenceOptimizer:
         # RESIZE CACHE
         ############################################################################################
         # Free memory ratio is hardcoded to 0.8 for now to ensure we have enough memory for graph capture.
-        resize_kv_cache(egm, cm, free_mem_ratio=0.8)
+        resize_kv_cache(egm, cm, local_rank, world_size, free_mem_ratio=0.8)
 
         ############################################################################################
         # COMPILE MODEL

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -163,7 +163,7 @@ class InferenceOptimizer:
         # RESIZE CACHE
         ############################################################################################
         # Free memory ratio is hardcoded to 0.8 for now to ensure we have enough memory for graph capture.
-        resize_kv_cache(egm, cm, local_rank, world_size, free_mem_ratio=0.8)
+        resize_kv_cache(egm, cm, world_size, free_mem_ratio=0.8)
 
         ############################################################################################
         # COMPILE MODEL


### PR DESCRIPTION
When resizing kv-caches, it is important to make sure all ranks have the same sized kv-cache.
## Test Coverage

Tested by running trtllm-bench:
`trtllm-bench --model meta-llama/Llama-3.1-8B throughput --dataset /tmp/synthetic_128_128.txt --backend autodeploy --tp=4`

On 4xH100
```
===========================================================                                                                                                                             
= PYTORCH BACKEND                                                                                                                                                                       
===========================================================                                                                                                                             
Model:                  meta-llama/Llama-3.1-8B                                                                                                                                         
Model Path:             None                                                                                                                                                            
TensorRT-LLM Version:   0.20.0rc1                                                                                                                                                       
Dtype:                  bfloat16                                                                                                                                                        
KV Cache Dtype:         None                                                                                                                                                            
Quantization:           None                                                                                                                                                            
                                                                                                                                                                                        
===========================================================                                                                                                                             
= REQUEST DETAILS                                                                                                                                                                       
===========================================================                                                                                                                             
Number of requests:             1000                                                                                                                                                    
Number of concurrent requests:  965.4331                                                                                                                                                
Average Input Length (tokens):  128.0000                                                                                                                                                
Average Output Length (tokens): 128.0000                                                                                                                                                
===========================================================                                                                                                                             
= WORLD + RUNTIME INFORMATION                 
===========================================================                                 
TP Size:                4                     
PP Size:                1                     
EP Size:                None                  
Max Runtime Batch Size: 4096                  
Max Runtime Tokens:     8192                  
Scheduling Policy:      GUARANTEED_NO_EVICT                                                 
KV Memory Percentage:   90.00%                
Issue Rate (req/sec):   3.2015E+14            

===========================================================                                 
= PERFORMANCE OVERVIEW                        
===========================================================                                 
Request Throughput (req/sec):                     61.6603                                   
Total Output Throughput (tokens/sec):             7892.5166                                 
Total Token Throughput (tokens/sec):              15785.0332                                
Total Latency (ms):                               16217.8943                                
Average request latency (ms):                     15657.2914                                
Per User Output Throughput [w/ ctx] (tps/user):   8.1765                                    
Per GPU Output Throughput (tps/gpu):              1973.1291           
```
## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
