### PR TITLE
[AutoDeploy] set default cache resize portion to 0.0

### DIFF
--- a/examples/auto_deploy/simple_config.py
+++ b/examples/auto_deploy/simple_config.py
@@ -76,7 +76,7 @@ class SimpleConfig:
     visualize: bool = False
 
     ### BENCHMARKING CONFIG ########################################################################
-    free_mem_ratio: float = 0.8  # specifies the fraction of available memory to occupy for cache
+    free_mem_ratio: float = 0.0  # specifies the fraction of available memory to occupy for cache
     benchmark: bool = False  # If true, set ISO to 2048 random int and OSL to 128
     benchmark_num: int = 10  # By default run 10 times and get average
     benchmark_isl: int = 2048  # input seq length for benchmarking

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
@@ -132,6 +132,10 @@ def resize_kv_cache(
         f"Current cache size: {current_cache_size}, Current num pages: {current_num_pages}"
     )
 
+    if free_mem_ratio == 0.0:
+        ad_logger.info(f"Skipping cache resize for {free_mem_ratio=}")
+        return
+
     try:
         # Let's run a forward pass to get the memory usage
         cm.info._set_max_num_tokens_sample()

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -209,8 +209,7 @@ class InferenceOptimizer:
         # initialize cache on correct device
         cm.initialize_caches()
 
-        # Free memory ratio is hardcoded to 0.8 for now to ensure we have enough memory for graph
-        # capture.
+        # resize kv cache to occupy the available GPU memory up to free_mem_ratio
         resize_kv_cache(egm, cm, free_mem_ratio=self.ad_config.free_mem_ratio)
 
         ############################################################################################


### PR DESCRIPTION
avoid cache resize if not necessary. We have seen failure cases where cache resize may cause illegal memory access