### PR TITLE
[AutoDeploy] ensure device id is in our device setting

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -90,6 +90,12 @@ class ADEngine(ModelEngine):
     ):
         """Build the ADEngine using the AutoDeployConfig that gets passed through from the LLM."""
 
+        # update device to contain the current default device if it's in cuda
+        device = torch.device(device)
+        if device.type == "cuda" and device.index is None:
+            device = torch.device(f"cuda:{torch.cuda.current_device()}")
+        device = str(device)
+
         # construct model factory
         model_kwargs = {"max_position_embeddings": seq_info.max_seq_len, **ad_config.model_kwargs}
         factory = ModelFactoryRegistry.get(ad_config.model_factory)(


### PR DESCRIPTION
Make sure device id is always set. It seems that the HF device_map doesn't respect default device id when the device passed in is just "cuda"