### PR TITLE
Removed load_state_dict() with assign=True

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -4,7 +4,7 @@ import json
 import os
 import types
 from contextlib import contextmanager, nullcontext
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Optional
 
 import torch
 import torch.nn as nn

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_hf.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_hf.py
@@ -9,7 +9,6 @@ from transformers.models.llama4.configuration_llama4 import Llama4Config
 from tensorrt_llm._torch.auto_deploy.models.hf import (
     AutoModelForCausalLMFactory,
     hf_load_state_dict_with_device,
-    load_state_dict_with_assign,
 )
 
 
@@ -17,36 +16,6 @@ class SimpleModel(nn.Module):
     def __init__(self):
         super().__init__()
         self.linear = nn.Linear(10, 10)
-
-
-def test_load_state_dict_with_assign():
-    """Test that load_state_dict_with_assign correctly patches torch.nn.Module.load_state_dict."""
-    # Instead of trying to test the implementation details of the context manager,
-    # let's focus on testing its behavior - that it causes assign=True to be used
-
-    # First, let's check the behavior when assign=True is used directly
-    model1 = SimpleModel()
-    model2 = SimpleModel()
-
-    # Create a state dict with modified parameters
-    new_weight = torch.randn_like(model1.linear.weight)
-    new_bias = torch.randn_like(model1.linear.bias)
-    state_dict = {"linear.weight": new_weight, "linear.bias": new_bias}
-
-    # Load with assign=True explicitly
-    model1.load_state_dict(state_dict, assign=True)
-
-    # Now load with the context manager
-    with load_state_dict_with_assign():
-        model2.load_state_dict(state_dict)
-
-    # Both models should have identical parameters
-    assert torch.all(model1.linear.weight == model2.linear.weight)
-    assert torch.all(model1.linear.bias == model2.linear.bias)
-
-    # And both should match the new values
-    assert torch.all(model1.linear.weight == new_weight)
-    assert torch.all(model2.linear.weight == new_weight)
 
 
 def test_hf_load_state_dict_with_device():


### PR DESCRIPTION
Removed load_state_dict_with_assign() context manager to retain the dtype of parameters during model initialization instead of dtype of parameters from the checkpoint. This will allow us to run deepseek tests without skipping weights
