### PR TITLE
[AutoDeploy] correctly identifying how to load HF checkpoint weights

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/models/factory.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/factory.py
@@ -93,37 +93,52 @@ class ModelFactory(ABC):
                 the same model that is built above but it needs to have a state dict compatible with
                 the model built above.
             device: The device to load the model on.
+
+        NOTE: we always call ``self._to_maybe_random(model, device)`` as a preprocessing step
+        to ensure the model parameters already exist on the right device and have the desired dtype
+        as set in the model architecture. Moreover, initializing weights will ensure that no
+        ``assign=True`` logic is triggered during state dict loading. We want to avoid this since
+        this can interfere with things like weight sharding loading hooks. Particularly,
+        ``assign=True`` can cause OOM issues because although we shard the weight it may still
+        reference the full weight tensor in memory and hence with ``assign=True`` memory equivalent
+        to the full weight tensor and hence the full model may be reserved on each rank.
+
+        NOTE: this function will roughly allocate the following amount of memory:
+
+            * ``skip_loading_weights=True``:
+
+                .. code-block:: python
+
+                    sum(t.element_size() * t.numel() for t in model.state_dict().values())
+
+            * ``skip_loading_weights=False``:
+
+                .. code-block:: python
+
+                    sum(t.element_size() * t.numel() for t in model.state_dict().values()) +
+                    <SIZE_OF_LARGEST_CHECKPOINT_FILE>
+
         """
         ad_logger.info("Loading and initializing weights.")
-        if self.skip_loading_weights:
-            self._load_random_init(model, device)
-        else:
+        self._to_maybe_random(model, device)
+        if not self.skip_loading_weights:
             self._load_checkpoint(model, device)
 
     @staticmethod
-    def _to_maybe_empty(model: nn.Module, device: DeviceLikeType):
-        """A mix of ``model.to(device)`` and ``model.to_empty(device)``.
+    def _to_maybe_random(model: nn.Module, device: DeviceLikeType):
+        """A mix of ``model.to(device)`` and random initialization of parameters.
 
         If a parameter is already initialized, then we will call `to()` on it. Otherwise, we will
-        initialize it with an empty tensor on the given device.
+        initialize it with a random tensor on the given device.
 
+        NOTE: this utility is written in such a fashion that not more memory than what the model
+        shard needs is reserved and/or allocated.
         """
         model._apply(
-            lambda t: torch.empty_like(t, device=device)
+            lambda t: torch.normal(0.0, 1.0, size=t.shape, device=device, dtype=t.dtype)
             if t.device == torch.device("meta")
             else t.to(device)
         )
-
-    @classmethod
-    def _load_random_init(cls, model: nn.Module, device: DeviceLikeType):
-        """Randomly initialize model."""
-        cls._to_maybe_empty(model, device)
-        state_dict = model.state_dict()
-        for k in state_dict:
-            state_dict[k] = torch.normal(0.0, 1.0, size=state_dict[k].shape, device=device).to(
-                state_dict[k].dtype
-            )
-        model.load_state_dict(state_dict, strict=True, assign=True)
 
     @abstractmethod
     def _load_checkpoint(self, model: nn.Module, device: DeviceLikeType):

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -4,7 +4,7 @@ import json
 import os
 import types
 from contextlib import contextmanager, nullcontext
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Optional
 
 import torch
 import torch.nn as nn

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -4,16 +4,22 @@ import json
 import os
 import types
 from contextlib import contextmanager, nullcontext
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import torch
 import torch.nn as nn
 from accelerate import init_empty_weights, load_checkpoint_and_dispatch
 from accelerate.utils import modeling
-from huggingface_hub import snapshot_download
-from huggingface_hub.utils import HFValidationError, validate_repo_id
+from huggingface_hub import HfApi, snapshot_download
+from huggingface_hub.utils import HFValidationError, filter_repo_objects, validate_repo_id
 from torch._prims_common import DeviceLikeType
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, PretrainedConfig
+from transformers.utils import (
+    SAFE_WEIGHTS_INDEX_NAME,
+    SAFE_WEIGHTS_NAME,
+    WEIGHTS_INDEX_NAME,
+    WEIGHTS_NAME,
+)
 
 from ..custom_ops.attention_interface import CacheConfig
 from ..utils.logger import ad_logger
@@ -160,8 +166,92 @@ class AutoModelForCausalLMFactory(ModelFactory):
             return None
         return self.autotokenizer_from_pretrained(self.model, **self.tokenizer_kwargs)
 
+    def _get_ignore_patterns(self, repo_id: str):
+        """Get the ignore patterns for the HF repo."""
+        ignore_patterns = ["*.pt", "*.pth"]
+        bin_pattern = "*.bin*"
+        safetensors_pattern = "*.safetensors*"
+        if self.skip_loading_weights:
+            ignore_patterns.extend([bin_pattern, safetensors_pattern])
+            return ignore_patterns
+
+        # now check if we can identify safetensors or bin ignore patterns from the repo
+        # make this totally fail-safe...
+        try:
+            validate_repo_id(repo_id)
+            api = HfApi()
+            repo_info = api.repo_info(repo_id)
+
+            # check files in the repo
+            files = [f.rfilename for f in repo_info.siblings]
+
+            # if we have safetensors we can ignore all bin files
+            if list(filter_repo_objects(items=files, allow_patterns=[safetensors_pattern])):
+                ignore_patterns.append(bin_pattern)
+        except:  # noqa: E722
+            pass
+
+        return ignore_patterns
+
+    def _get_checkpoint_file(self, checkpoint: Union[str, os.PathLike]) -> Union[str, os.PathLike]:
+        """Get the most relevant checkpoint file from the HF checkpoint directory.
+
+        Args:
+            checkpoint: The path to the checkpoint directory or file.
+
+        Returns:
+            The path to the most relevant checkpoint file.
+
+        Following order of precedence for the checkpoint file:
+
+            1. checkpoint is a file
+            2. checkpoint dir contains SAFE_WEIGHTS_INDEX_NAME
+            3. checkpoint dir contains SAFE_WEIGHTS_NAME
+            4. checkpoint dir contains WEIGHTS_INDEX_NAME
+            5. checkpoint dir contains WEIGHTS_NAME
+
+        """
+
+        if os.path.isfile(checkpoint):
+            return checkpoint
+
+        # Verify that checkpoint is a directory
+        if not os.path.isdir(checkpoint):
+            raise ValueError(
+                f"Checkpoint path '{checkpoint}' is neither a file nor a directory, or does not exist."
+            )
+
+        # now check which is the most relevant checkpoint file
+        safe_weights_index_path = os.path.join(checkpoint, SAFE_WEIGHTS_INDEX_NAME)
+        if os.path.isfile(safe_weights_index_path):
+            return safe_weights_index_path
+
+        safe_weights_path = os.path.join(checkpoint, SAFE_WEIGHTS_NAME)
+        if os.path.isfile(safe_weights_path):
+            return safe_weights_path
+
+        weights_index_path = os.path.join(checkpoint, WEIGHTS_INDEX_NAME)
+        if os.path.isfile(weights_index_path):
+            return weights_index_path
+
+        weights_path = os.path.join(checkpoint, WEIGHTS_NAME)
+        if os.path.isfile(weights_path):
+            return weights_path
+
+        raise ValueError(
+            f"Could not find any model weights in {checkpoint}. "
+            f"Expected one of the following files: {SAFE_WEIGHTS_INDEX_NAME}, {SAFE_WEIGHTS_NAME}, "
+            f"{WEIGHTS_INDEX_NAME}, or {WEIGHTS_NAME}."
+        )
+
     def prefetch_checkpoint(self):
-        """Prefetch checkpoint from a HF repo if needed."""
+        """Prefetch checkpoint from a HF repo if needed.
+
+        We support the native HF/torch formats in the following order of precedence:
+
+            1. safetensors
+            2. pytorch_model.bin
+        """
         # already prefetched
         if self._prefetched_path:
             return
@@ -173,12 +263,8 @@ class AutoModelForCausalLMFactory(ModelFactory):
         except HFValidationError:
             is_hf_repo = False
         if is_hf_repo:
-            # we don't expect to use bin files or pt/pth checkpoint files (they are quite large)
-            ignore_patterns = ["*.bin", "*.pt", "*.pth"]
-            # we will also ignore the .safetensors files if we skip loading weights
-            if self.skip_loading_weights:
-                ignore_patterns.append("*.safetensors")
             ad_logger.info("Pre-fetching checkpoint directory from HF repo.")
+            ignore_patterns = self._get_ignore_patterns(self.model)
             fetched_dir = snapshot_download(self.model, ignore_patterns=ignore_patterns)
         else:
             fetched_dir = self.model
@@ -197,9 +283,12 @@ class AutoModelForCausalLMFactory(ModelFactory):
         # prefetch if needed
         self.prefetch_checkpoint()
 
+        # identify the most relevant checkpoint file
+        ckpt_file = self._get_checkpoint_file(self.model)
+
         # reuse the load checkpoint utility from accelerate
         with hf_load_state_dict_with_device(device):
-            load_checkpoint_and_dispatch(model, checkpoint=self.model)
+            load_checkpoint_and_dispatch(model, checkpoint=ckpt_file)
 
     def _load_quantization_config(self):
         assert self.model

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_hf.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_hf.py
@@ -9,7 +9,6 @@ from transformers.models.llama4.configuration_llama4 import Llama4Config
 from tensorrt_llm._torch.auto_deploy.models.hf import (
     AutoModelForCausalLMFactory,
     hf_load_state_dict_with_device,
-    load_state_dict_with_assign,
 )
 
 
@@ -17,36 +16,6 @@ class SimpleModel(nn.Module):
     def __init__(self):
         super().__init__()
         self.linear = nn.Linear(10, 10)
-
-
-def test_load_state_dict_with_assign():
-    """Test that load_state_dict_with_assign correctly patches torch.nn.Module.load_state_dict."""
-    # Instead of trying to test the implementation details of the context manager,
-    # let's focus on testing its behavior - that it causes assign=True to be used
-
-    # First, let's check the behavior when assign=True is used directly
-    model1 = SimpleModel()
-    model2 = SimpleModel()
-
-    # Create a state dict with modified parameters
-    new_weight = torch.randn_like(model1.linear.weight)
-    new_bias = torch.randn_like(model1.linear.bias)
-    state_dict = {"linear.weight": new_weight, "linear.bias": new_bias}
-
-    # Load with assign=True explicitly
-    model1.load_state_dict(state_dict, assign=True)
-
-    # Now load with the context manager
-    with load_state_dict_with_assign():
-        model2.load_state_dict(state_dict)
-
-    # Both models should have identical parameters
-    assert torch.all(model1.linear.weight == model2.linear.weight)
-    assert torch.all(model1.linear.bias == model2.linear.bias)
-
-    # And both should match the new values
-    assert torch.all(model1.linear.weight == new_weight)
-    assert torch.all(model2.linear.weight == new_weight)
 
 
 def test_hf_load_state_dict_with_device():


### PR DESCRIPTION
- [x] Our current load logic (recommended meta device/hf accelerate approach) requires us to correctly identify which type of checkpoint we want to load from a HF checkpoint directory (safetsensors or bin). It won't choose for us. --> This will correctly filter for the approach prioritizing safetsensors over bin

- [x] In addition this PR will also ensure that we don't allocate too much memory during checkpoint loading for sharded models. The added comments in the PR give more details about that.

- [x] It also includes #22