### PR TITLE
Several Bug Fix: bias missing for linear/lift canonicalize_graph to meta device/enhance attention op args extraction

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
@@ -9,6 +9,7 @@ from torch.fx import Node
 
 from ..utils.cuda_graph import cuda_graph_state
 from ..utils.logger import ad_logger
+from ..utils.node_utils import extract_op_args
 from .attention_interface import (
     AttentionDescriptor,
     AttentionLayout,
@@ -399,7 +400,9 @@ class FlashInferAttention(AttentionDescriptor):
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
         # Double check other arguments
-        attn_mask, dropout_p, is_causal = source_attn_node.args[3:6]
+        attn_mask, dropout_p, is_causal = extract_op_args(
+            source_attn_node, "attn_mask", "dropout_p", "is_causal"
+        )
         if attn_mask is not None or dropout_p != 0.0 or not is_causal:
             ad_logger.warning(
                 "Unsupported attention arguments for "

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
@@ -10,6 +10,7 @@ from torch._subclasses import FakeTensor
 from torch.fx import Node
 
 from ..utils.logger import ad_logger
+from ..utils.node_utils import extract_op_args
 from .attention_interface import (
     AttentionDescriptor,
     AttentionLayout,
@@ -364,8 +365,9 @@ class TritonWithFlattenedInputs(AttentionDescriptor):
         k_fake: FakeTensor = source_attn_node.args[1].meta["val"]
         head_dim = k_fake.shape[3]
 
-        # Double check other arguments
-        attn_mask, dropout_p, is_causal = source_attn_node.args[3:6]
+        attn_mask, dropout_p, is_causal = extract_op_args(
+            source_attn_node, "attn_mask", "dropout_p", "is_causal"
+        )
         if attn_mask is not None or dropout_p != 0.0 or not is_causal:
             ad_logger.warning(
                 "Unsupported attention arguments for "

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -11,7 +11,7 @@ from ..distributed import common as dist_ad
 from ..models.factory import ModelFactory
 from ..shim.interface import AutoDeployConfig, CachedSequenceInterface
 from ..utils.logger import ad_logger
-from ._graph import canonicalize_graph, move_to_device
+from ._graph import canonicalize_graph, lift_to_meta, move_to_device
 from .export import torch_export_to_gm
 from .library import (
     check_in_out_nodes,
@@ -151,8 +151,9 @@ class InferenceOptimizer:
         egm = dp_bmm_shard(egm, local_rank, world_size)
 
         # let's run a shape propagation pass to update the graph with correct meta values for
-        # subsequent optimization passes
-        egm = canonicalize_graph(egm, shape_prop=True)
+        # subsequent optimization passes. Lift state_dict to meta as shape propagation involves device check
+        with lift_to_meta(egm):
+            egm = canonicalize_graph(egm, shape_prop=True)
 
         ############################################################################################
         # MOVE MODEL AND LOAD WEIGHTS

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -350,3 +350,38 @@ def extract_output_tuple(node: Node, count: int = 2):
         )
         results.append(user_node)
     return results
+
+
+def extract_op_args(node: Node, *arg_names):
+    """
+    Given a call_function node for torch custom op,
+    returns a tuple of values for each name in arg_names, trying in order:
+    1. node.kwargs[name]
+    2. node.args[position_in_schema]
+    3. the schema default
+    """
+    if node.op != "call_function":
+        raise ValueError(f"extract_op_args only supports call_function nodes, got {node.op}")
+
+    op = node.target
+    schema = next(iter(op._schemas.values()))
+    args_meta = schema.arguments
+
+    # name→index in signature, and name→default_value
+    pos = {a.name: i for i, a in enumerate(args_meta)}
+    defs = {a.name: a.default_value for a in args_meta if a.has_default_value}
+
+    args = list(node.args)
+    kwargs = node.kwargs or {}
+
+    def _get(name):
+        if name in kwargs:
+            return kwargs[name]
+        i = pos.get(name)
+        if i is not None and i < len(args):
+            return args[i]
+        if name in defs:
+            return defs[name]
+        raise RuntimeError(f"Could not find a value for '{name}' on op {op}")
+
+    return tuple(_get(n) for n in arg_names)

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -364,7 +364,12 @@ def extract_op_args(node: Node, *arg_names):
         raise ValueError(f"extract_op_args only supports call_function nodes, got {node.op}")
 
     op = node.target
-    schema = next(iter(op._schemas.values()))
+    if hasattr(op, "_schemas"):
+        schema = next(iter(op._schemas.values()))
+    elif hasattr(op, "_schema"):
+        schema = op._schema
+    else:
+        raise RuntimeError(f"No schema found on op {op}")
     args_meta = schema.arguments
 
     # name→index in signature, and name→default_value
@@ -384,4 +389,4 @@ def extract_op_args(node: Node, *arg_names):
             return defs[name]
         raise RuntimeError(f"Could not find a value for '{name}' on op {op}")
 
-    return tuple(_get(n) for n in arg_names)
+    return [_get(n) for n in arg_names]


### PR DESCRIPTION
## Description

1. Patch torch.ops.linear.simple to always gets bias arg in export pipeline
Fix for the failure:
```
RuntimeError: linear::simple() is missing value for argument 'bias'. Declaration: linear::simple(Tensor input, Tensor weight, Tensor? bias) -> Tensor
```
for granite moe models/ apple models

2. Lift the state_dict canonicalize_graph with shape prop to meta device, since shape propagation does same device check for ops like aten.mul
3. Update args extraction logic of attention custom op: able to extract from kwargs and get default value from op schema

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
