### PR TITLE
Fix for attention argument dropout_p='None' 

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
@@ -158,8 +158,8 @@ def match_causal_attn_mask(gm: GraphModule) -> GraphModule:
                     node.args[len(new_args)] if len(node.args) > len(new_args) else None
                 )
             new_args.append(True)  # Append is_causal=True
-            
-            #In the case dropout_p is set to default value, it is not captured in node.args. Set it to 0.0 in this case
+
+            # In the case dropout_p is set to default value, it is not captured in node.args. Set it to 0.0 in this case
             new_args[4] = 0.0 if new_args[4] is None else new_args[4]
 
         # Create new node with updated arguments

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
@@ -158,6 +158,9 @@ def match_causal_attn_mask(gm: GraphModule) -> GraphModule:
                     node.args[len(new_args)] if len(node.args) > len(new_args) else None
                 )
             new_args.append(True)  # Append is_causal=True
+            
+            #In the case dropout_p is set to default value, it is not captured in node.args. Set it to 0.0 in this case
+            new_args[4] = 0.0 if new_args[4] is None else new_args[4]
 
         # Create new node with updated arguments
         with graph.inserting_before(node):

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
@@ -144,23 +144,21 @@ def match_causal_attn_mask(gm: GraphModule) -> GraphModule:
 
         ad_logger.debug(f"Found causal attention mask at {node}")
 
+        # construct the new args list with args provided to the node and the default values otherwise
+        new_args = []
+        for idx, arg in enumerate(node.target._schema.arguments):
+            # In case arg is provided to the node, use it
+            if idx < len(node.args):
+                new_args.append(node.args[idx])
+            # In case arg is not provided to the node, use the default value
+            elif arg.has_default_value:
+                new_args.append(arg.default_value)
+            else:
+                raise ValueError(f"Missing required argument: {arg.name}")
+
         # Create new arguments with None mask and is_causal=True
-        new_args = list(node.args)
         new_args[3] = None  # Set mask to None
-
-        # Check if we have enough arguments to set is_causal
-        if len(new_args) > 5:
-            new_args[5] = True  # Set is_causal to True
-        else:
-            # If is_causal wasn't specified (using default value), extend args
-            while len(new_args) < 5:
-                new_args.append(
-                    node.args[len(new_args)] if len(node.args) > len(new_args) else None
-                )
-            new_args.append(True)  # Append is_causal=True
-
-            # In the case dropout_p is set to default value, it is not captured in node.args. Set it to 0.0 in this case
-            new_args[4] = 0.0 if new_args[4] is None else new_args[4]
+        new_args[5] = True  # Set is_causal to True
 
         # Create new node with updated arguments
         with graph.inserting_before(node):


### PR DESCRIPTION
In some cases, during torch export default values are not captured in the graph (one case is when we set all default values for kwargs). This breaks the auto deploy pipeline as `match_causal_attn_mask()` sets these values to None. Updated logic to set values to default if not provided to the node.