### PR TITLE
Support loading other model's tokenizer for apple models

### DIFF
--- a/examples/auto_deploy/build_and_run_ad.py
+++ b/examples/auto_deploy/build_and_run_ad.py
@@ -76,9 +76,7 @@ def build_llm_from_config(config: SimpleConfig) -> LLM:
         build_config=build_config,
         pytorch_backend_config=ad_config,
         tensor_parallel_size=config.world_size,
-        tokenizer=factory.init_tokenizer(config.tokenizer_name)
-        if config.customize_tokenizer
-        else None,
+        tokenizer=factory.init_tokenizer(config.tokenizer) if config.customize_tokenizer else None,
     )
 
     return llm

--- a/examples/auto_deploy/build_and_run_ad.py
+++ b/examples/auto_deploy/build_and_run_ad.py
@@ -76,7 +76,9 @@ def build_llm_from_config(config: SimpleConfig) -> LLM:
         build_config=build_config,
         pytorch_backend_config=ad_config,
         tensor_parallel_size=config.world_size,
-        tokenizer=factory.init_tokenizer() if config.customize_tokenizer else None,
+        tokenizer=factory.init_tokenizer(config.tokenizer_name)
+        if config.customize_tokenizer
+        else None,
     )
 
     return llm

--- a/examples/auto_deploy/build_and_run_ad.py
+++ b/examples/auto_deploy/build_and_run_ad.py
@@ -60,6 +60,7 @@ def build_llm_from_config(config: SimpleConfig) -> LLM:
     factory = ModelFactoryRegistry.get(config.model_factory)(
         model=config.model,
         model_kwargs=config.model_kwargs,
+        tokenizer=config.tokenizer,
         tokenizer_kwargs=config.tokenizer_kwargs,
         skip_loading_weights=config.skip_loading_weights,
     )
@@ -76,7 +77,7 @@ def build_llm_from_config(config: SimpleConfig) -> LLM:
         build_config=build_config,
         pytorch_backend_config=ad_config,
         tensor_parallel_size=config.world_size,
-        tokenizer=factory.init_tokenizer(config.tokenizer) if config.customize_tokenizer else None,
+        tokenizer=factory.init_tokenizer() if config.customize_tokenizer else None,
     )
 
     return llm

--- a/examples/auto_deploy/simple_config.py
+++ b/examples/auto_deploy/simple_config.py
@@ -47,6 +47,9 @@ class SimpleConfig:
     # [here](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/tokenization_llama_fast.py#L127).
     # NOTE: This is only used if customize_tokenizer is True
     tokenizer_kwargs: Dict = field(default_factory=dict)
+    # Specify to load the tokenizer of another model via the model's name
+    # NOTE: This is only used if customize_tokenizer is True
+    tokenizer_name: str = None
 
     ### CONFIGURE BACKEND, RUNTIME, AND WORLD SIZE ##################################
     world_size: int = 1  # choose from number of GPUs for TP (0--> no TP, no spawned processes)

--- a/examples/auto_deploy/simple_config.py
+++ b/examples/auto_deploy/simple_config.py
@@ -18,9 +18,9 @@ class SimpleConfig:
     # 1. Sharded checkpoint (multiple files) in the safetensors format
     # 2. Single, unsharded checkpoint in the safetensors format
     # 3. Single, unsharded checkpoint in the pytorch format (.pt/.pth) file ending.
-    # If no `model` argument is provided, the checkpoint directory is used to infer the model
-    # architecture.
-    model: Optional[str] = None
+    model: str
+    # same as model. None defaults to model. Only used if customize_tokenizer is True
+    tokenizer: Optional[str] = None
     model_factory: Literal["AutoModelForCausalLM", "AutoModelForImageTextToText"] = (
         "AutoModelForCausalLM"
     )
@@ -47,9 +47,6 @@ class SimpleConfig:
     # [here](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/tokenization_llama_fast.py#L127).
     # NOTE: This is only used if customize_tokenizer is True
     tokenizer_kwargs: Dict = field(default_factory=dict)
-    # Specify to load the tokenizer of another model via the model's name
-    # NOTE: This is only used if customize_tokenizer is True
-    tokenizer_name: str = None
 
     ### CONFIGURE BACKEND, RUNTIME, AND WORLD SIZE ##################################
     world_size: int = 1  # choose from number of GPUs for TP (0--> no TP, no spawned processes)

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -175,11 +175,14 @@ class AutoModelForCausalLMFactory(ModelFactory):
             kv_cache_dtype = None
         return CacheConfig(dtype=kv_cache_dtype)
 
-    def init_tokenizer(self) -> Optional[Any]:
-        """Initialize the tokenizer for the model."""
-        if not self.model:
+    def init_tokenizer(self, tokenizer_name: str = None) -> Optional[Any]:
+        """Initialize the tokenizer—either a custom name or the model's default."""
+        if self.model is None and tokenizer_name is None:
             return None
-        return self.autotokenizer_from_pretrained(self.model, **self.tokenizer_kwargs)
+
+        # prefer a user-specified tokenizer_name, otherwise use the model ID
+        target = tokenizer_name or self.model
+        return self.autotokenizer_from_pretrained(target, **self.tokenizer_kwargs)
 
     def _get_ignore_patterns(self, repo_id: str):
         """Get the ignore patterns for the HF repo."""

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -4,7 +4,7 @@ import json
 import os
 import types
 from contextlib import contextmanager, nullcontext
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -184,12 +184,13 @@ class AutoModelForCausalLMFactory(ModelFactory):
         target = tokenizer_name or self.model
         return self.autotokenizer_from_pretrained(target, **self.tokenizer_kwargs)
 
-    def _get_ignore_patterns(self, repo_id: str):
+    @staticmethod
+    def _get_ignore_patterns(repo_id: str, skip_prefetch_weights: bool) -> List[str]:
         """Get the ignore patterns for the HF repo."""
         ignore_patterns = ["*.pt", "*.pth"]
         bin_pattern = "*.bin*"
         safetensors_pattern = "*.safetensors*"
-        if self.skip_loading_weights:
+        if skip_prefetch_weights:
             ignore_patterns.extend([bin_pattern, safetensors_pattern])
             return ignore_patterns
 
@@ -262,7 +263,7 @@ class AutoModelForCausalLMFactory(ModelFactory):
             f"{WEIGHTS_INDEX_NAME}, or {WEIGHTS_NAME}."
         )
 
-    def prefetch_checkpoint(self):
+    def _prefetch_checkpoint(self, model_name_or_path: str, skip_prefetch_weights: bool) -> str:
         """Prefetch checkpoint from a HF repo if needed.
 
         We support the native HF/torch formats in the following order of precedence:
@@ -270,27 +271,23 @@ class AutoModelForCausalLMFactory(ModelFactory):
             1. safetensors
             2. pytorch_model.bin
         """
-        # already prefetched
-        if self._prefetched_path:
-            return
-
         # check if it's a repo id and if so download the repo
         is_hf_repo = True
         try:
-            validate_repo_id(self.model)
+            validate_repo_id(model_name_or_path)
         except HFValidationError:
             is_hf_repo = False
         if is_hf_repo:
             ad_logger.info("Pre-fetching checkpoint directory from HF repo.")
-            ignore_patterns = self._get_ignore_patterns(self.model)
-            fetched_dir = snapshot_download(self.model, ignore_patterns=ignore_patterns)
+            ignore_patterns = self._get_ignore_patterns(model_name_or_path, skip_prefetch_weights)
+            fetched_dir = snapshot_download(model_name_or_path, ignore_patterns=ignore_patterns)
         else:
-            fetched_dir = self.model
+            fetched_dir = model_name_or_path
 
         # at this point it should be a directory (either the original one or the download dir)
         assert os.path.isdir(fetched_dir), f"Checkpoint path {fetched_dir} is not a directory."
 
-        self._prefetched_path = fetched_dir
+        return fetched_dir
 
     def _load_checkpoint(self, model: nn.Module, device: DeviceLikeType):
         """Load the checkpoint into the model."""

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -175,14 +175,11 @@ class AutoModelForCausalLMFactory(ModelFactory):
             kv_cache_dtype = None
         return CacheConfig(dtype=kv_cache_dtype)
 
-    def init_tokenizer(self, tokenizer_name: str = None) -> Optional[Any]:
+    def init_tokenizer(self) -> Optional[Any]:
         """Initialize the tokenizer—either a custom name or the model's default."""
-        if self.model is None and tokenizer_name is None:
+        if self.tokenizer is None:
             return None
-
-        # prefer a user-specified tokenizer_name, otherwise use the model ID
-        target = tokenizer_name or self.model
-        return self.autotokenizer_from_pretrained(target, **self.tokenizer_kwargs)
+        return self.autotokenizer_from_pretrained(self.tokenizer, **self.tokenizer_kwargs)
 
     @staticmethod
     def _get_ignore_patterns(repo_id: str, skip_prefetch_weights: bool) -> List[str]:

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_hf.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_hf.py
@@ -66,7 +66,7 @@ def mock_factory():
         # Create factory instance with mocked methods to avoid HTTP requests
         factory = AutoModelForCausalLMFactory(model="dummy_model")
         # Set model path directly to avoid prefetch
-        factory._prefetched_path = "/dummy/path"
+        factory._prefetched_model_path = "/dummy/path"
         yield factory
 
 


### PR DESCRIPTION
## Description

Test command:
```
python build_and_run_ad.py --config '{"world_size":1, "model":"apple/OpenELM-3B-Instruct", "attn_backend":"FlashInfer", "compile_backend":"torch-compile", "benchmark": false,"customize_tokenizer":true, "tokenizer_name":"meta-llama/Llama-2-7b-hf"}'  --model-kwargs '{}' 
```
Need to set both `customize_tokenizer` and `tokenizer_name`,

model list:
```
apple/OpenELM-3B-Instruct
apple/OpenELM-1_1B-Instruct
apple/OpenELM-270M-Instruct
apple/OpenELM-450M-Instruct
```

Prompt output is still not coherent after loading the tokenzier, e.g.
```
[05/27/2025-21:44:46] [TRT-LLM AUTO-DEPLOY] [I] [PROMPT 0] How big is the universe? : 1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
[05/27/2025-21:44:46] [TRT-LLM AUTO-DEPLOY] [I] [PROMPT 1] In simple words and in a single sentence, explain the concept of gravity: : 
Gravity is the force that acts between two objects due to which all bodies with mass and accelerates them towards each other.
In simple words.
Gravity.
Gravity.
Gravity.
Gravity.
Gravity.
Gravity.
G.
G.
G.
G.
In physics.
In physics.
In physics.
In physics.
In physics.
In physics.
In
```

There's warning about attention_mask not supported in the log. Not sure if that's related.

**TODO:**
update dashboard config

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
