### PR TITLE
[AutoDeploy] clean-up and speed-up for unit tests

### DIFF
--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/custom_ops/test_moe_ep.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/custom_ops/test_moe_ep.py
@@ -91,8 +91,8 @@ def _run_moe_ep_test(num_experts: int, topk: int, rank: int, world_size: int):
     torch.testing.assert_close(output_trt, ref_output, rtol=5e-2, atol=5e-2)
 
 
-@pytest.mark.parametrize("num_experts", [8, 10])
-@pytest.mark.parametrize("topk", [3, 4])
+@pytest.mark.parametrize("num_experts", [10])
+@pytest.mark.parametrize("topk", [3, 10])
 @pytest.mark.parametrize("device_count", get_device_counts())
 def test_moe_ep(device_count, num_experts, topk):
     spawn_multiprocess_job(job=partial(_run_moe_ep_test, num_experts, topk), size=device_count)

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
@@ -1,118 +1,27 @@
 """Testing build_and_run_ad end2end."""
 
-from typing import Dict, Optional
+from typing import Dict
 
 import pytest
-from _model_test_utils import _hf_model_dir_or_hub_id
+from _model_test_utils import get_small_model_config
 from build_and_run_ad import main
 from simple_config import SimpleConfig
-from utils.llm_data import llm_models_root
 
 
+@pytest.mark.parametrize("world_size", [1, 2])
 @pytest.mark.parametrize(
-    "world_size, config",
+    "config",
     [
-        # small llama3.1-8B model with world_size 2
-        (
-            2,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct",
-                    "meta-llama/Meta-Llama-3.1-8B-Instruct",
-                ),
-                "runtime": "demollm",
-                "attn_backend": "TritonWithFlattenedInputs",
-                "compile_backend": "torch-simple",
-                "model_kwargs": {"num_hidden_layers": 2},
-            },
-        ),
-        # small llama3.1-8B model with world_size 2 + trtllm runtime + torch-opt
-        (
-            2,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct",
-                    "meta-llama/Meta-Llama-3.1-8B-Instruct",
-                ),
-                "runtime": "trtllm",
-                "attn_backend": "TritonWithFlattenedInputs",
-                "compile_backend": "torch-opt",
-                "model_kwargs": {"num_hidden_layers": 2},
-            },
-        ),
-        # small Mixtral-8x7B model with world_size 2
-        (
-            2,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/Mixtral-8x7B-Instruct-v0.1",
-                    "mistralai/Mixtral-8x7B-Instruct-v0.1",
-                ),
-                "runtime": "demollm",
-                "attn_backend": "TritonWithFlattenedInputs",
-                "compile_backend": "torch-simple",
-                "model_kwargs": {"num_hidden_layers": 2},
-            },
-        ),
-        # small deepseek-v3 model with world_size 4
-        (
-            2,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/DeepSeek-V3",
-                    "deepseek-ai/DeepSeek-V3",
-                ),
-                "runtime": "demollm",
-                "attn_backend": "TritonWithFlattenedInputs",
-                "compile_backend": "torch-simple",
-                "model_kwargs": {
-                    "num_hidden_layers": 6,
-                    "hidden_size": 32,
-                    "max_position_embeddings": 2048,
-                    "intermediate_size": 16,
-                    "moe_intermediate_size": 16,
-                    "n_routed_experts": 16,
-                    "num_attention_heads": 8,
-                    "num_key_value_heads": 4,
-                },
-                "skip_loading_weights": "True",
-            },
-        ),
-        # small llama4-scout model with world_size 1 (processes are spawned)
-        (
-            2,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/Llama-4-Scout-17B-16E-Instruct",
-                    "meta-llama/Llama-4-Scout-17B-16E-Instruct",
-                ),
-                "model_factory": "AutoModelForImageTextToText",
-                "runtime": "demollm",
-                "attn_backend": "FlashInfer",
-                "compile_backend": "torch-opt",
-                "customize_tokenizer": True,
-                "model_kwargs": {
-                    "text_config": {
-                        "num_hidden_layers": 2,
-                        "head_dim": 64,
-                        "Hidden_size": 512,
-                        "intermediate_size": 2048,
-                        "intermediate_size_mlp": 2048,
-                        "num_attention_heads": 16,
-                        "num_key_value_heads": 8,
-                    },
-                    "vision_config": {
-                        "num_hidden_layers": 2,
-                    },
-                },
-            },
+        get_small_model_config(
+            "meta-llama/Meta-Llama-3.1-8B-Instruct",
+            attn_backend="FlashInfer",
+            compile_backend="torch-opt",
         ),
     ],
 )
-def test_build_ad(world_size: Optional[int], config: Dict):
+def test_build_ad(world_size: int, config: Dict):
+    config["world_size"] = world_size
+    config["runtime"] = "trtllm"  # Default runtime set to trtllm
     simple_config = SimpleConfig(**config)
-    simple_config.world_size = world_size
-    simple_config.skip_loading_weights = True
-    simple_config.free_mem_ratio = 0.01  # we don't need the cache and it may cause OOM issues
     print(f"Simple Config: {simple_config}")
     main(simple_config)

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_ep_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_ep_sharding.py
@@ -47,7 +47,7 @@ def _run_ep_shard_job(num_experts: int, rank: int, world_size: int) -> None:
 
 
 @pytest.mark.parametrize("device_count", get_device_counts())
-@pytest.mark.parametrize("num_experts", [3, 4, 8, 10])
+@pytest.mark.parametrize("num_experts", [3, 8])
 def test_ep_shard(device_count: int, num_experts: int):
     dist_common.spawn_multiprocess_job(
         job=partial(_run_ep_shard_job, num_experts),

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -1,122 +1,46 @@
 """Testing build_and_run_ad end2end."""
 
-from typing import Dict, Optional
+from typing import Dict
 
 import pytest
-from _model_test_utils import _hf_model_dir_or_hub_id
+from _model_test_utils import get_small_model_config
 from build_and_run_ad import main
 from simple_config import SimpleConfig
-from utils.llm_data import llm_models_root
 
 
 @pytest.mark.parametrize(
-    "world_size, config",
+    "config",
     [
-        # small llama3.1-8B model with world_size 1 (processes are spawned)
-        (
-            1,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct",
-                    "meta-llama/Meta-Llama-3.1-8B-Instruct",
-                ),
-                "runtime": "demollm",
-                "attn_backend": "TritonWithFlattenedInputs",
-                "compile_backend": "torch-simple",
-                "model_kwargs": {"num_hidden_layers": 2},
-            },
+        get_small_model_config(
+            "meta-llama/Meta-Llama-3.1-8B-Instruct",
+            attn_backend="FlashInfer",
+            compile_backend="torch-opt",
         ),
-        # small llama3.1-8B model with world_size 1 + trtllm runtime
-        (
-            1,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct",
-                    "meta-llama/Meta-Llama-3.1-8B-Instruct",
-                ),
-                "runtime": "trtllm",
-                "attn_backend": "TritonWithFlattenedInputs",
-                "compile_backend": "torch-simple",
-                "model_kwargs": {"num_hidden_layers": 2},
-            },
+        get_small_model_config(
+            "mistralai/Mixtral-8x7B-Instruct-v0.1",
+            attn_backend="TritonWithFlattenedInputs",
+            compile_backend="torch-simple",
         ),
-        # small Mixtral-8x7B model with world_size 1
-        (
-            1,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/Mixtral-8x7B-Instruct-v0.1",
-                    "mistralai/Mixtral-8x7B-Instruct-v0.1",
-                ),
-                "runtime": "demollm",
-                "attn_backend": "TritonWithFlattenedInputs",
-                "compile_backend": "torch-simple",
-                "model_kwargs": {"num_hidden_layers": 2},
-            },
+        get_small_model_config(
+            "microsoft/Phi-3-mini-4k-instruct",
+            attn_backend="TritonWithFlattenedInputs",
+            compile_backend="torch-simple",
         ),
-        # small llama3.1-8B model with world_size 0 (no processes are spawned) + torch-opt
-        (
-            0,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct",
-                    "meta-llama/Meta-Llama-3.1-8B-Instruct",
-                ),
-                "runtime": "demollm",
-                "attn_backend": "TritonWithFlattenedInputs",
-                "compile_backend": "torch-opt",
-                "model_kwargs": {"num_hidden_layers": 2},
-            },
+        get_small_model_config(
+            "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+            attn_backend="FlashInfer",
+            compile_backend="torch-opt",
         ),
-        # small Phi3-mini-4k model with world_size 1
-        (
-            1,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/Phi-3/Phi-3-mini-4k-instruct",
-                    "microsoft/Phi-3-mini-4k-instruct",
-                ),
-                "runtime": "demollm",
-                "attn_backend": "TritonWithFlattenedInputs",
-                "compile_backend": "torch-simple",
-                "model_kwargs": {"num_hidden_layers": 2},
-            },
-        ),
-        # small llama4-scout model with world_size 1 (processes are spawned)
-        (
-            1,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/Llama-4-Scout-17B-16E-Instruct",
-                    "meta-llama/Llama-4-Scout-17B-16E-Instruct",
-                ),
-                "model_factory": "AutoModelForImageTextToText",
-                "runtime": "demollm",
-                "attn_backend": "FlashInfer",
-                "compile_backend": "torch-opt",
-                "customize_tokenizer": True,
-                "model_kwargs": {
-                    "text_config": {
-                        "num_hidden_layers": 2,
-                        "head_dim": 64,
-                        "Hidden_size": 512,
-                        "intermediate_size": 2048,
-                        "intermediate_size_mlp": 2048,
-                        "num_attention_heads": 16,
-                        "num_key_value_heads": 8,
-                    },
-                    "vision_config": {
-                        "num_hidden_layers": 2,
-                    },
-                },
-            },
+        get_small_model_config(
+            "deepseek-ai/DeepSeek-V3",
+            attn_backend="TritonWithFlattenedInputs",
+            compile_backend="torch-simple",
         ),
     ],
 )
-def test_build_ad(world_size: Optional[int], config: Dict):
+def test_build_ad(config: Dict):
+    config["runtime"] = "demollm"  # Default runtime set to demollm
+    config["world_size"] = 0  # Default world_size set to 0
     simple_config = SimpleConfig(**config)
-    simple_config.world_size = world_size
-    simple_config.skip_loading_weights = True
-    simple_config.free_mem_ratio = 0.01  # we don't need the cache and it may cause OOM issues
     print(f"Simple Config: {simple_config}")
     main(simple_config)


### PR DESCRIPTION
Fast unit test execution for AutoDeploy

* cleaned up unit tests
* removed redundant test configs for slow tests
* investigated parallel unit test execution

Previously
```bash
✗ pytest tests/unittest/_torch/auto_deploy/unit 

=== 717 passed, 58 skipped, 42 xfailed, 4 xpassed, 10 warnings in 514.78s (0:08:34) ===
````

Now
```bash
✗ pytest -n auto --dist=worksteal tests/unittest/_torch/auto_deploy/unit

=== 705 passed, 58 skipped, 42 xfailed, 4 xpassed, 52 warnings in 81.16s (0:01:21) ===
```

515 /81 = 6.35x speedup