### PR TITLE
Fix `sampling_params.top_k is None` issue for demollm

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, List, Optional, Tuple
 import torch
 import torch.multiprocessing as mp
 
+from ...._torch.pyexecutor.sampler import greedy_search_sampling_batch, top_k_sampling_batch
 from ....executor import GenerationExecutor
 from ....executor.request import GenerationRequest
 from ....executor.result import CompletionOutput, GenerationResult
@@ -204,12 +205,8 @@ class DemoEngine(ADEngine):
         logits_shape = logits.shape
         logits = logits.view(-1, logits_shape[-1])  # sampling_batch expects 2D logits
         if isinstance(sampling_params.top_k, int):
-            from tensorrt_llm._torch.pyexecutor.sampler import top_k_sampling_batch
-
             idx_next, probs = top_k_sampling_batch(logits, sampling_params.top_k)
         else:
-            from tensorrt_llm._torch.pyexecutor.sampler import greedy_search_sampling_batch
-
             idx_next, probs = greedy_search_sampling_batch(logits)
         idx_next = idx_next.view(logits_shape[:-1])
         return idx_next, probs
@@ -218,10 +215,6 @@ class DemoEngine(ADEngine):
         self, logits_last: torch.Tensor, sampling_params: SamplingParams
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Returns a sampled token per input sequence and associating probability."""
-        if sampling_params.top_k == 1:  # greedy decoding
-            # idx_next is the index of the max logit for each sequence
-            idx_next = logits_last.argmax(dim=-1, keepdim=False)
-            return idx_next, logits_last.squeeze(-1)
         # run sampling
         return self._sample(logits_last, sampling_params)
 

--- a/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
@@ -7,11 +7,11 @@ from typing import Any, Callable, List, Optional, Tuple
 import torch
 import torch.multiprocessing as mp
 
-from ...._torch.pyexecutor.sampler import greedy_search_sampling_batch, top_k_sampling_batch
 from ....executor import GenerationExecutor
 from ....executor.request import GenerationRequest
 from ....executor.result import CompletionOutput, GenerationResult
 from ....sampling_params import SamplingParams
+from ...pyexecutor.sampler import greedy_search_sampling_batch, top_k_sampling_batch
 from ..distributed import common as dist_ad
 from ..utils.logger import ad_logger
 from .ad_executor import ADEngine

--- a/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
@@ -201,11 +201,16 @@ class DemoEngine(ADEngine):
     def _sample(
         cls, logits: torch.Tensor, sampling_params: SamplingParams
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        from tensorrt_llm._torch.pyexecutor.sampler import top_k_sampling_batch
-
         logits_shape = logits.shape
-        logits = logits.view(-1, logits_shape[-1])  # top_k_sampling_batch expects 2D logits
-        idx_next, probs = top_k_sampling_batch(logits, sampling_params.top_k)
+        logits = logits.view(-1, logits_shape[-1])  # sampling_batch expects 2D logits
+        if isinstance(sampling_params.top_k, int):
+            from tensorrt_llm._torch.pyexecutor.sampler import top_k_sampling_batch
+
+            idx_next, probs = top_k_sampling_batch(logits, sampling_params.top_k)
+        else:
+            from tensorrt_llm._torch.pyexecutor.sampler import greedy_search_sampling_batch
+
+            idx_next, probs = greedy_search_sampling_batch(logits)
         idx_next = idx_next.view(logits_shape[:-1])
         return idx_next, probs
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_engine.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_engine.py
@@ -78,26 +78,54 @@ def test_engine(engine_cls: Type[ADEngine], attn_backend: str, attn_page_size: i
         original_logits = get_inference_model(mock_input)(input_ids[0].unsqueeze(0))[0]
         assert torch.allclose(logits, original_logits, atol=1e-5), "Generated Token ID mismatch"
 
-        if isinstance(engine, DemoEngine):
-            # Tests for sampling
-            vocab_size = logits.size(-1)
-            sampling_params = SamplingParams(top_k=5, temperature=1.0)
 
-            token_ids, _ = engine._sample(logits, sampling_params)
+@pytest.mark.parametrize("attn_page_size", [0, 2])
+def test_demo_engine_sampling(attn_page_size: int):
+    """Test sampling logic specific to DemoEngine."""
+    seed = 0
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
 
-            expected_shape = logits.shape[:-1]
-            assert token_ids.shape == expected_shape, (
-                f"Unexpected shape for sampled token IDs, expected {expected_shape} , but got {token_ids.shape}"
-            )
-            assert torch.all((token_ids >= 0) & (token_ids < vocab_size)), (
-                "Sampled indices out of range"
-            )
+    device = torch.device("cuda")
+    max_seq_len = 64
+    max_batch_size = 8
 
-            # Test topk=1 produce same output as Greedy Search
-            sampling_params_greedy = SamplingParams(top_k=1)
-            sampling_params_none = SamplingParams(top_k=None)
+    sequence_info = SequenceInfo(
+        max_seq_len=max_seq_len,
+        max_batch_size=max_batch_size,
+        page_size=attn_page_size,
+    )
+    sequence_info.to(device)
 
-            token_ids_1, _ = engine._sample(logits, sampling_params_greedy)
-            token_ids_2, _ = engine._sample(logits, sampling_params_none)
+    engine = DemoEngine(get_inference_model, sequence_info, device)
 
-            torch.testing.assert_close(token_ids_1, token_ids_2)
+    with torch.inference_mode():
+        input_ids = [torch.tensor([1, 2, 3, 4], device=device)]
+        sequence_info.reset()
+        sequence_info.nest_sequences(input_ids)
+        engine.cache_seq_interface.info.sync(sequence_info)
+        logits = engine._compute_logits()
+        logits = torch.stack(logits)
+
+        vocab_size = logits.size(-1)
+        sampling_params = SamplingParams(top_k=5, temperature=1.0)
+
+        token_ids, _ = engine._sample(logits, sampling_params)
+        expected_shape = logits.shape[:-1]
+
+        assert token_ids.shape == expected_shape, (
+            f"Unexpected shape for sampled token IDs, expected {expected_shape}, but got {token_ids.shape}"
+        )
+        assert torch.all((token_ids >= 0) & (token_ids < vocab_size)), (
+            "Sampled indices out of range"
+        )
+
+        # Test that top_k=1 (greedy) matches top_k=None (argmax fallback)
+        sampling_params_greedy = SamplingParams(top_k=1)
+        sampling_params_none = SamplingParams(top_k=None)
+
+        token_ids_1, _ = engine._sample(logits, sampling_params_greedy)
+        token_ids_2, _ = engine._sample(logits, sampling_params_none)
+
+        torch.testing.assert_close(token_ids_1, token_ids_2)


### PR DESCRIPTION
## Description

1. update DemoEngine to handle case `sampling_params.top_k=None`, will run greedy search if `sampling_params.top_k=None`. The default value is 200. Added an unit test for the sampler.


**NOTE**:
We can enable trtllm runtime with topk sampling using `--args.mixed-sampler True` in the new config system.


## Test Coverage

Passes unit tests and `test_ad_build.py`, didn't test `test_lm_eval.py`
<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
