### PR TITLE
feat:[AutoDeploy] Support Quantized MoE matcher - Step1

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_moe.py
@@ -45,7 +45,7 @@ def torch_moe(
         valid_mask, selected_experts, torch.full_like(selected_experts, num_experts)
     )
     # Create one-hot encoding with an extra class.
-    one_hot = torch.nn.functional.one_hot(selected_experts_fixed, num_classes=num_experts + 1)
+    one_hot = F.one_hot(selected_experts_fixed, num_classes=num_experts + 1)
     expert_mask = one_hot[..., :num_experts].permute(2, 1, 0)
 
     for expert_idx in range(num_experts):

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_moe.py
@@ -283,6 +283,9 @@ def torch_fp4_moe(
     for expert_idx in range(num_experts):
         idx, top_x = torch.where(expert_mask[expert_idx])
         tokens_for_expert = x[None, top_x].reshape(-1, hidden_dim)
+
+        if not tokens_for_expert.shape[0]:
+            continue  # input of shape [0, hidden_dim] breaks fp4 kernel
         gate_out = torch.ops.quant.fp4_linear(
             tokens_for_expert,
             w1_weight[expert_idx],
@@ -334,5 +337,4 @@ def torch_fp4_moe(
     w2_alpha: List[torch.Tensor],
     w3_alpha: List[torch.Tensor],
 ) -> torch.Tensor:
-    # Fake implementation for tracing/testing
     return torch.empty_like(x)

--- a/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
@@ -59,7 +59,7 @@ def load_buffers_and_params(
         if clone:
             v_new = v.detach().clone()
             if isinstance(v, torch.nn.Parameter):
-                v_new = nn.Parameter(v_new)
+                v_new = nn.Parameter(v_new, requires_grad=False)
         else:
             v_new = state_dict[k]
         setattr(submod, name, v_new)

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/__init__.py
@@ -8,6 +8,7 @@ from .fused_moe import *
 from .fusion import *
 from .kvcache import *
 from .quantization import *
+from .quantize_moe import *
 from .rope import *
 from .sharding import *
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/ep_sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/ep_sharding.py
@@ -12,7 +12,7 @@ The sharding process consists of:
 1. Identify MoE nodes in the FX graph
 2. Compute local sharding parameters (`selected_experts` and `final_scales`) to update the routing tensors.
 3. Partition expert weight lists according to the current rank and world size,
-    and replace the MoE node’s arguments with these sharded versions.
+    and replace the MoE node's arguments with these sharded versions.
 4. Append an all_reduce node after each MoE node to aggregate outputs across devices,
     then canonicalize the modified graph.
 
@@ -38,7 +38,10 @@ def ep_shard(gm: GraphModule, rank: int, world_size: int) -> None:
     assert isinstance(gm, GraphModule), "Expecting GraphModule"
     num_moe_patterns = 0
     for node in list(gm.graph.nodes):
-        if not is_op(node, torch.ops.auto_deploy.torch_moe):
+        if not is_op(
+            node,
+            (torch.ops.auto_deploy.torch_moe, torch.ops.moe.torch_fp8_moe, torch.ops.moe.torch_fp4_moe),
+        ):
             continue
         _insert_sharded_moe(gm, node, rank, world_size)
         num_moe_patterns += 1
@@ -59,6 +62,8 @@ def _insert_sharded_moe(
     sharded `selected_experts` and `final_scales(router_logics)`.
     Add an all_reduce node after the moe node.
     """
+    is_fp8 = is_op(node, torch.ops.moe.torch_fp8_moe)
+    is_fp4 = is_op(node, torch.ops.moe.torch_fp4_moe)
     num_experts = len(node.args[3])
     args = list(node.args)
 
@@ -114,6 +119,13 @@ def _insert_sharded_moe(
     args[3] = w1_list_sharded
     args[4] = w2_list_sharded
     args[5] = w3_list_sharded
+
+    if is_fp8:
+        for i in range(6):
+            args[6 + i] = get_partition(args[6 + i], world_size, rank)
+    elif is_fp4:
+        for i in range(9):
+            args[6 + i] = get_partition(args[6 + i], world_size, rank)
 
     ad_logger.debug(
         f"Updated node {node}: replaced original arguments {node.args} with sharded arguments {args}."

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/ep_sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/ep_sharding.py
@@ -40,7 +40,7 @@ def ep_shard(gm: GraphModule, rank: int, world_size: int) -> None:
     for node in list(gm.graph.nodes):
         if not is_op(
             node,
-            (torch.ops.auto_deploy.torch_moe, torch.ops.moe.torch_fp8_moe, torch.ops.moe.torch_fp4_moe),
+            (torch.ops.auto_deploy.torch_moe, torch.ops.auto_deploy.torch_fp8_moe, torch.ops.auto_deploy.torch_fp4_moe),
         ):
             continue
         _insert_sharded_moe(gm, node, rank, world_size)
@@ -62,8 +62,8 @@ def _insert_sharded_moe(
     sharded `selected_experts` and `final_scales(router_logics)`.
     Add an all_reduce node after the moe node.
     """
-    is_fp8 = is_op(node, torch.ops.moe.torch_fp8_moe)
-    is_fp4 = is_op(node, torch.ops.moe.torch_fp4_moe)
+    is_fp8 = is_op(node, torch.ops.auto_deploy.torch_fp8_moe)
+    is_fp4 = is_op(node, torch.ops.auto_deploy.torch_fp4_moe)
     num_experts = len(node.args[3])
     args = list(node.args)
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/ep_sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/ep_sharding.py
@@ -42,8 +42,8 @@ def ep_shard(gm: GraphModule, rank: int, world_size: int) -> None:
             node,
             (
                 torch.ops.auto_deploy.torch_moe,
-                torch.ops.auto_deploy.torch_fp8_moe,
-                torch.ops.auto_deploy.torch_fp4_moe,
+                torch.ops.auto_deploy.torch_quant_fp8_moe,
+                torch.ops.auto_deploy.torch_quant_fp4_moe,
             ),
         ):
             continue
@@ -66,8 +66,8 @@ def _insert_sharded_moe(
     sharded `selected_experts` and `final_scales(router_logics)`.
     Add an all_reduce node after the moe node.
     """
-    is_fp8 = is_op(node, torch.ops.auto_deploy.torch_fp8_moe)
-    is_fp4 = is_op(node, torch.ops.auto_deploy.torch_fp4_moe)
+    is_fp8 = is_op(node, torch.ops.auto_deploy.torch_quant_fp8_moe)
+    is_fp4 = is_op(node, torch.ops.auto_deploy.torch_quant_fp4_moe)
     num_experts = len(node.args[3])
     args = list(node.args)
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/ep_sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/ep_sharding.py
@@ -40,7 +40,11 @@ def ep_shard(gm: GraphModule, rank: int, world_size: int) -> None:
     for node in list(gm.graph.nodes):
         if not is_op(
             node,
-            (torch.ops.auto_deploy.torch_moe, torch.ops.auto_deploy.torch_fp8_moe, torch.ops.auto_deploy.torch_fp4_moe),
+            (
+                torch.ops.auto_deploy.torch_moe,
+                torch.ops.auto_deploy.torch_fp8_moe,
+                torch.ops.auto_deploy.torch_fp4_moe,
+            ),
         ):
             continue
         _insert_sharded_moe(gm, node, rank, world_size)

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
@@ -21,8 +21,8 @@ def match_moe_pattern(gm: GraphModule) -> None:
 
     for start_boundary, end_boundary in zip(boundary_nodes[:-1], boundary_nodes[1:]):
         # Step 1: Identify Expert Compute pattern
-        pattern_input_nodes, pattern_output_nodes, expert_weights = _match_expert_compute_pattern(
-            start_boundary, end_boundary
+        (pattern_input_nodes, pattern_output_nodes, expert_weights, expert_scales, weight_type) = (
+            _match_expert_compute_pattern(start_boundary, end_boundary)
         )
         if not expert_weights:
             continue
@@ -56,29 +56,49 @@ def match_moe_pattern(gm: GraphModule) -> None:
         if final_hidden_state_node is None:
             continue
 
-        # Step 5: Insert the moe op into the graph.
+        # Step 5: Insert the MoE op into the graph.
         ad_logger.debug(
-            f"""Found MoE Pattern: between boundary {start_boundary} and {end_boundary}.\n
-            Capturing input hidden states node: {hidden_states},
-            selected_experts node: {selected_experts}, routing_weights node: {normalized_routing_weights},
-            expert weights : {expert_weights} """
+            f"Found MoE Pattern: between boundary {start_boundary} and {end_boundary}.\n"
+            f"Input hidden states node: {hidden_states}, "
+            f"selected_experts node: {selected_experts}, "
+            f"routing_weights node: {normalized_routing_weights}, "
+            f"expert weights: {expert_weights}, weight type: {weight_type}"
         )
         with graph.inserting_before(final_hidden_state_node):
             w1_list = expert_weights["w1"]
             w2_list = expert_weights["w2"]
             w3_list = expert_weights["w3"]
 
-            fused_moe_node = graph.call_function(
-                torch.ops.auto_deploy.torch_moe,
-                args=(
-                    hidden_states,
-                    selected_experts,
-                    normalized_routing_weights,
-                    w1_list,
-                    w2_list,
-                    w3_list,
-                ),
-            )
+            if weight_type == "fp8":
+                fused_moe_node = graph.call_function(
+                    torch.ops.moe.torch_fp8_moe,
+                    args=(
+                        hidden_states,
+                        selected_experts,
+                        normalized_routing_weights,
+                        w1_list,
+                        w2_list,
+                        w3_list,
+                        expert_scales["w1_input_scale"],
+                        expert_scales["w2_input_scale"],
+                        expert_scales["w3_input_scale"],
+                        expert_scales["w1_weight_scale"],
+                        expert_scales["w2_weight_scale"],
+                        expert_scales["w3_weight_scale"],
+                    ),
+                )
+            else:
+                fused_moe_node = graph.call_function(
+                    torch.ops.auto_deploy.torch_moe,
+                    args=(
+                        hidden_states,
+                        selected_experts,
+                        normalized_routing_weights,
+                        w1_list,
+                        w2_list,
+                        w3_list,
+                    ),
+                )
 
         final_hidden_state_node.replace_all_uses_with(fused_moe_node)
         graph.erase_node(final_hidden_state_node)
@@ -143,6 +163,7 @@ def _insert_fused_moe_ops(gm: GraphModule) -> int:
 
         with graph.inserting_before(node):
             new_node = graph.call_function(
+                # TODO: torch.ops.moe.trtllm_fused_moe for unquantized models,
                 torch.ops.auto_deploy.trtllm_moe_fused,
                 args=(
                     hidden_states,
@@ -224,6 +245,37 @@ def _find_lowest_common_ancessor(nodes: list[Node]) -> Optional[Node]:
     return common
 
 
+def _extract_linear_parameters(linear_node: Node) -> tuple[Node, torch.Tensor, Optional[dict], str]:
+    """
+    Given a linear op node, extract the input tensor node, weight tensor,
+    any quantization scales (if the op is quantized), and return a weight type.
+
+    For a torch.ops.linear.simple.default op:
+      - Returns (input_node, weight, None, "simple")
+
+    For a torch.ops.quant.fp8_linear op:
+      - Returns (input_node, weight, {"input_scale": input_scale, "weight_scale": weight_scale}, "fp8")
+    """
+    input_node = linear_node.args[0]
+    if is_op(linear_node, torch.ops.quant.fp8_linear):
+        weight = linear_node.args[1]
+        input_scale = linear_node.kwargs.get("input_scale", None)
+        weight_scale = linear_node.kwargs.get("weight_scale", None)
+
+        # in case input_scale and weight_scale is not provided by kwargs
+        # args layout is (input, weight, bias, input_scale, weight_scale)
+        if input_scale is None and len(linear_node.args) >= 4:
+            input_scale = linear_node.args[3]
+        if weight_scale is None and len(linear_node.args) >= 5:
+            weight_scale = linear_node.args[4]
+        return input_node, weight, {"input_scale": input_scale, "weight_scale": weight_scale}, "fp8"
+    elif is_op(linear_node, torch.ops.linear.simple):
+        weight = linear_node.args[1]
+        return input_node, weight, None, "simple"
+    else:
+        return None, None, None, ""
+
+
 def _match_expert_compute_pattern(start_boundary: Node, end_boundary: Node):
     """
     Match the expert compute pattern between the given boundaries.
@@ -232,24 +284,38 @@ def _match_expert_compute_pattern(start_boundary: Node, end_boundary: Node):
 
         (F.silu(x @ w1.t()) * (x @ w3.t())) @ w2.t()
 
-    For each expert, the function returns:
-      - pattern_input_nodes: a list of input nodes (x) used for the expert compute.
-      - pattern_output_nodes: a list of final expert output nodes (the linear op with weight w2).
-      - expert_weights: a dict with keys "w1", "w2", and "w3" mapping to lists of
-        corresponding weight nodes from the w1, w2, and w3 branches.
+    For each expert, the function extracts the input node from the w1 branch and
+    collects the weight parameters from three linear ops (w1, w3, and w2 branches).
+
+    This function supports both:
+      - torch.ops.linear.simple.default ops, and
+      - torch.ops.quant.fp8_linear ops (in which case it also extracts quantization scales).
+
+    Returns:
+        A tuple:
+          (pattern_input_nodes, pattern_output_nodes, expert_weights, expert_scales, weight_type)
+
+          - pattern_input_nodes: List of input nodes (x) used for the expert compute.
+          - pattern_output_nodes: List of final expert output nodes (the linear op with weight w2).
+          - expert_weights: Dict with keys "w1", "w2", "w3" mapping to lists of weight tensors.
+          - expert_scales: Dict with keys "w1_input_scale", "w1_weight_scale", etc., containing scale tensors
+                           (empty if weight_type is "simple").
+          - weight_type: "fp8" if FP8 ops were used, "simple" otherwise.
     """
     pattern_input_nodes, pattern_output_nodes = [], []
     expert_weights = defaultdict(list)
+    expert_scales = defaultdict(list)
+    weight_type = "simple"  # default
 
     nodes = list(start_boundary.graph.nodes)
     region_nodes = nodes[nodes.index(start_boundary) + 1 : nodes.index(end_boundary)]
 
     for node in region_nodes:
-        if not is_linear_op(node):
+        # Accept both simple and quantized linear ops.
+        if not is_linear_op(node, include_quantization=True):
             continue
 
         final_linear = node
-        # Must have at least one argument, and that first argument must be a Node.
         if not final_linear.args or not isinstance(final_linear.args[0], Node):
             continue
 
@@ -258,7 +324,6 @@ def _match_expert_compute_pattern(start_boundary: Node, end_boundary: Node):
             continue
 
         arg_a, arg_b = mul_node.args[:2]
-        # Pick the silu op from either arg_a or arg_b.
         silu_node = (
             arg_a
             if (isinstance(arg_a, Node) and is_op(arg_a, torch.ops.aten.silu))
@@ -272,25 +337,35 @@ def _match_expert_compute_pattern(start_boundary: Node, end_boundary: Node):
         if not (
             silu_node.args
             and isinstance(silu_node.args[0], Node)
-            and is_linear_op(silu_node.args[0])
+            and is_linear_op(silu_node.args[0], include_quantization=True)
         ):
             continue
         linear_w1_node = silu_node.args[0]
 
         # The other branch should be a linear op (w3 branch).
         linear_w3_node = arg_b if arg_a is silu_node else arg_a
-        if not (isinstance(linear_w3_node, Node) and is_linear_op(linear_w3_node)):
+        if not (
+            isinstance(linear_w3_node, Node)
+            and is_linear_op(linear_w3_node, include_quantization=True)
+        ):
             continue
         if not (linear_w1_node.args and linear_w3_node.args):
             continue
 
-        input_node_w1 = linear_w1_node.args[0]
-        weight_w1 = linear_w1_node.args[1] if len(linear_w1_node.args) > 1 else None
-        weight_w3 = linear_w3_node.args[1] if len(linear_w3_node.args) > 1 else None
-        weight_w2 = final_linear.args[1] if len(final_linear.args) > 1 else None
+        # Extract parameters from each linear op.
+        input_node_w1, weight_w1, quant_params_w1, wt_type_w1 = _extract_linear_parameters(
+            linear_w1_node
+        )
+        _, weight_w3, quant_params_w3, wt_type_w3 = _extract_linear_parameters(linear_w3_node)
+        _, weight_w2, quant_params_w2, wt_type_w2 = _extract_linear_parameters(final_linear)
 
         if None in (weight_w1, weight_w3, weight_w2):
             continue
+
+        # Ensure the weight type is consistent across branches.
+        if wt_type_w1 != wt_type_w3 or wt_type_w1 != wt_type_w2:
+            continue
+        weight_type = wt_type_w1
 
         pattern_input_nodes.append(input_node_w1)
         pattern_output_nodes.append(final_linear)
@@ -298,7 +373,16 @@ def _match_expert_compute_pattern(start_boundary: Node, end_boundary: Node):
         expert_weights["w3"].append(weight_w3)
         expert_weights["w2"].append(weight_w2)
 
-    return pattern_input_nodes, pattern_output_nodes, expert_weights
+        # TODO: sanity check that all experts have same weight type
+        if weight_type == "fp8":
+            expert_scales["w1_input_scale"].append(quant_params_w1["input_scale"])
+            expert_scales["w1_weight_scale"].append(quant_params_w1["weight_scale"])
+            expert_scales["w3_input_scale"].append(quant_params_w3["input_scale"])
+            expert_scales["w3_weight_scale"].append(quant_params_w3["weight_scale"])
+            expert_scales["w2_input_scale"].append(quant_params_w2["input_scale"])
+            expert_scales["w2_weight_scale"].append(quant_params_w2["weight_scale"])
+
+    return pattern_input_nodes, pattern_output_nodes, expert_weights, expert_scales, weight_type
 
 
 def _find_final_hidden_state_node(

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
@@ -90,12 +90,22 @@ def match_moe_pattern(gm: GraphModule) -> None:
             elif weight_type == "fp4":
                 fused_moe_node = graph.call_function(
                     torch.ops.moe.torch_fp4_moe,
-                    args = (
-                        hidden_states, selected_experts, normalized_routing_weights,
-                        w1_list, w2_list, w3_list,
-                        expert_scales["w1_input_scale"], expert_scales["w2_input_scale"], expert_scales["w3_input_scale"],
-                        expert_scales["w1_weight_scale"], expert_scales["w2_weight_scale"], expert_scales["w3_weight_scale"],
-                        expert_scales["w1_alpha"],       expert_scales["w2_alpha"],       expert_scales["w3_alpha"],
+                    args=(
+                        hidden_states,
+                        selected_experts,
+                        normalized_routing_weights,
+                        w1_list,
+                        w2_list,
+                        w3_list,
+                        expert_scales["w1_input_scale"],
+                        expert_scales["w2_input_scale"],
+                        expert_scales["w3_input_scale"],
+                        expert_scales["w1_weight_scale"],
+                        expert_scales["w2_weight_scale"],
+                        expert_scales["w3_weight_scale"],
+                        expert_scales["w1_alpha"],
+                        expert_scales["w2_alpha"],
+                        expert_scales["w3_alpha"],
                     ),
                 )
             else:
@@ -282,19 +292,23 @@ def _extract_linear_parameters(linear_node: Node) -> tuple[Node, torch.Tensor, O
         return input_node, weight, {"input_scale": input_scale, "weight_scale": weight_scale}, "fp8"
     elif is_op(linear_node, torch.ops.quant.fp4_linear):
         weight = linear_node.args[1]
-        input_scale  = linear_node.kwargs.get("input_scale", None)
+        input_scale = linear_node.kwargs.get("input_scale", None)
         weight_scale = linear_node.kwargs.get("weight_scale", None)
-        alpha        = linear_node.kwargs.get("alpha", None)
+        alpha = linear_node.kwargs.get("alpha", None)
         # fallback to positional args if absent
         args = linear_node.args
-        if input_scale  is None and len(args) >= 4: input_scale  = args[3]
-        if weight_scale is None and len(args) >= 5: weight_scale = args[4]
-        if alpha        is None and len(args) >= 6: alpha        = args[5]
-        return input_node, weight, {
-            "input_scale":  input_scale,
-            "weight_scale": weight_scale,
-            "alpha":        alpha
-        }, "fp4"
+        if input_scale is None and len(args) >= 4:
+            input_scale = args[3]
+        if weight_scale is None and len(args) >= 5:
+            weight_scale = args[4]
+        if alpha is None and len(args) >= 6:
+            alpha = args[5]
+        return (
+            input_node,
+            weight,
+            {"input_scale": input_scale, "weight_scale": weight_scale, "alpha": alpha},
+            "fp4",
+        )
     elif is_op(linear_node, torch.ops.linear.simple):
         weight = linear_node.args[1]
         return input_node, weight, None, "simple"

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
@@ -71,7 +71,7 @@ def match_moe_pattern(gm: GraphModule) -> None:
 
             if weight_type == "fp8":
                 fused_moe_node = graph.call_function(
-                    torch.ops.moe.torch_fp8_moe,
+                    torch.ops.auto_deploy.torch_fp8_moe,
                     args=(
                         hidden_states,
                         selected_experts,
@@ -89,7 +89,7 @@ def match_moe_pattern(gm: GraphModule) -> None:
                 )
             elif weight_type == "fp4":
                 fused_moe_node = graph.call_function(
-                    torch.ops.moe.torch_fp4_moe,
+                    torch.ops.auto_deploy.torch_fp4_moe,
                     args=(
                         hidden_states,
                         selected_experts,
@@ -137,7 +137,7 @@ def match_moe_pattern(gm: GraphModule) -> None:
 
 def fuse_moe(gm: torch.fx.GraphModule) -> None:
     """
-    Scan the FX graph and replace all calls to torch.ops.moe.torch_moe with
+    Scan the FX graph and replace all calls to torch.ops.auto_deploy.torch_moe with
     torch.ops.auto_deploy.trtllm_moe_fused.
     """
     ad_logger.debug("Before MoE fusion: " + str(gm))
@@ -184,7 +184,7 @@ def _insert_fused_moe_ops(gm: GraphModule) -> int:
 
         with graph.inserting_before(node):
             new_node = graph.call_function(
-                # TODO: torch.ops.moe.trtllm_fused_moe for unquantized models,
+                # TODO: torch.ops.auto_deploy.trtllm_fused_moe for unquantized models,
                 torch.ops.auto_deploy.trtllm_moe_fused,
                 args=(
                     hidden_states,
@@ -271,14 +271,16 @@ def _extract_linear_parameters(linear_node: Node) -> tuple[Node, torch.Tensor, O
     Given a linear op node, extract the input tensor node, weight tensor,
     any quantization scales (if the op is quantized), and return a weight type.
 
-    For a torch.ops.linear.simple.default op:
+    For a torch.ops.auto_deploy.torch_linear_simple.default op:
       - Returns (input_node, weight, None, "simple")
 
-    For a torch.ops.quant.fp8_linear op:
+    For a torch.ops.auto_deploy.torch_quant_fp8_linear op:
       - Returns (input_node, weight, {"input_scale": input_scale, "weight_scale": weight_scale}, "fp8")
+       For a torch.ops.auto_deploy.torch_quant_fp4_linear op:
+      - Returns (input_node, weight, {"input_scale": input_scale, "weight_scale": weight_scale, "alpha": alpha}, "fp4")
     """
     input_node = linear_node.args[0]
-    if is_op(linear_node, torch.ops.quant.fp8_linear):
+    if is_op(linear_node, torch.ops.auto_deploy.torch_quant_fp8_linear):
         weight = linear_node.args[1]
         input_scale = linear_node.kwargs.get("input_scale", None)
         weight_scale = linear_node.kwargs.get("weight_scale", None)
@@ -290,7 +292,7 @@ def _extract_linear_parameters(linear_node: Node) -> tuple[Node, torch.Tensor, O
         if weight_scale is None and len(linear_node.args) >= 5:
             weight_scale = linear_node.args[4]
         return input_node, weight, {"input_scale": input_scale, "weight_scale": weight_scale}, "fp8"
-    elif is_op(linear_node, torch.ops.quant.fp4_linear):
+    elif is_op(linear_node, torch.ops.auto_deploy.torch_quant_fp4_linear):
         weight = linear_node.args[1]
         input_scale = linear_node.kwargs.get("input_scale", None)
         weight_scale = linear_node.kwargs.get("weight_scale", None)
@@ -309,7 +311,7 @@ def _extract_linear_parameters(linear_node: Node) -> tuple[Node, torch.Tensor, O
             {"input_scale": input_scale, "weight_scale": weight_scale, "alpha": alpha},
             "fp4",
         )
-    elif is_op(linear_node, torch.ops.linear.simple):
+    elif is_op(linear_node, torch.ops.auto_deploy.torch_linear_simple):
         weight = linear_node.args[1]
         return input_node, weight, None, "simple"
     else:
@@ -328,8 +330,9 @@ def _match_expert_compute_pattern(start_boundary: Node, end_boundary: Node):
     collects the weight parameters from three linear ops (w1, w3, and w2 branches).
 
     This function supports both:
-      - torch.ops.linear.simple.default ops, and
-      - torch.ops.quant.fp8_linear ops (in which case it also extracts quantization scales).
+      - torch.ops.auto_deploy.torch_linear_simple.default ops, and
+      - torch.ops.auto_deploy.torch_quant_fp8_linear ops (also extracts quantization scales).
+      - torch.ops.auto_deploy.torch_quant_fp4_linear ops (also extracts quantization scales).
 
     Returns:
         A tuple:

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
@@ -87,6 +87,17 @@ def match_moe_pattern(gm: GraphModule) -> None:
                         expert_scales["w3_weight_scale"],
                     ),
                 )
+            elif weight_type == "fp4":
+                fused_moe_node = graph.call_function(
+                    torch.ops.moe.torch_fp4_moe,
+                    args = (
+                        hidden_states, selected_experts, normalized_routing_weights,
+                        w1_list, w2_list, w3_list,
+                        expert_scales["w1_input_scale"], expert_scales["w2_input_scale"], expert_scales["w3_input_scale"],
+                        expert_scales["w1_weight_scale"], expert_scales["w2_weight_scale"], expert_scales["w3_weight_scale"],
+                        expert_scales["w1_alpha"],       expert_scales["w2_alpha"],       expert_scales["w3_alpha"],
+                    ),
+                )
             else:
                 fused_moe_node = graph.call_function(
                     torch.ops.auto_deploy.torch_moe,
@@ -269,6 +280,21 @@ def _extract_linear_parameters(linear_node: Node) -> tuple[Node, torch.Tensor, O
         if weight_scale is None and len(linear_node.args) >= 5:
             weight_scale = linear_node.args[4]
         return input_node, weight, {"input_scale": input_scale, "weight_scale": weight_scale}, "fp8"
+    elif is_op(linear_node, torch.ops.quant.fp4_linear):
+        weight = linear_node.args[1]
+        input_scale  = linear_node.kwargs.get("input_scale", None)
+        weight_scale = linear_node.kwargs.get("weight_scale", None)
+        alpha        = linear_node.kwargs.get("alpha", None)
+        # fallback to positional args if absent
+        args = linear_node.args
+        if input_scale  is None and len(args) >= 4: input_scale  = args[3]
+        if weight_scale is None and len(args) >= 5: weight_scale = args[4]
+        if alpha        is None and len(args) >= 6: alpha        = args[5]
+        return input_node, weight, {
+            "input_scale":  input_scale,
+            "weight_scale": weight_scale,
+            "alpha":        alpha
+        }, "fp4"
     elif is_op(linear_node, torch.ops.linear.simple):
         weight = linear_node.args[1]
         return input_node, weight, None, "simple"
@@ -381,6 +407,16 @@ def _match_expert_compute_pattern(start_boundary: Node, end_boundary: Node):
             expert_scales["w3_weight_scale"].append(quant_params_w3["weight_scale"])
             expert_scales["w2_input_scale"].append(quant_params_w2["input_scale"])
             expert_scales["w2_weight_scale"].append(quant_params_w2["weight_scale"])
+        elif weight_type == "fp4":
+            expert_scales["w1_input_scale"].append(quant_params_w1["input_scale"])
+            expert_scales["w1_weight_scale"].append(quant_params_w1["weight_scale"])
+            expert_scales["w1_alpha"].append(quant_params_w1["alpha"])
+            expert_scales["w3_input_scale"].append(quant_params_w3["input_scale"])
+            expert_scales["w3_weight_scale"].append(quant_params_w3["weight_scale"])
+            expert_scales["w3_alpha"].append(quant_params_w3["alpha"])
+            expert_scales["w2_input_scale"].append(quant_params_w2["input_scale"])
+            expert_scales["w2_weight_scale"].append(quant_params_w2["weight_scale"])
+            expert_scales["w2_alpha"].append(quant_params_w2["alpha"])
 
     return pattern_input_nodes, pattern_output_nodes, expert_weights, expert_scales, weight_type
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/quantize_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/quantize_moe.py
@@ -1,0 +1,167 @@
+from functools import partial
+from typing import Any, Callable, Dict, List, Tuple
+
+import torch
+import torch.nn as nn
+from torch.fx import GraphModule, Node
+
+from ...utils.logger import ad_logger
+from ...utils.node_utils import is_op
+from ...utils.quantization_utils import QuantizationImpl, should_skip_quantization
+from .._graph import canonicalize_graph
+
+quantized_moe_op_map = {
+    "FP8": torch.ops.auto_deploy.torch_quant_fp8_moe,
+    "NVFP4": torch.ops.auto_deploy.torch_quant_fp4_moe,
+}
+
+
+def _quantize_moe_node(
+    gm: GraphModule,
+    node: Node,
+    quant_impl: QuantizationImpl,
+    quantized_op: Callable[..., Node],
+):
+    """
+    Replace a torch.ops.auto_deploy.torch_moe node with its quantized version,
+    quantizing each expert weight list and registering scales + hooks.
+    Automatically handles different scale configurations per quantization type.
+    """
+    w1_names, w2_names, w3_names = _extract_moe_weight_param_lists(node)
+
+    scale_keys = quant_impl.scale_names()
+
+    def quantize_param_list(weight_names: List[str]) -> Tuple[List[Node], List[List[Node]]]:
+        new_attrs = []
+        scale_nodes_group = []
+        for name in weight_names:
+            orig_weight = gm.get_parameter(name)
+            new_weight = quant_impl.quantize_weight(orig_weight)
+
+            # Replace parameter in submodule
+            modname, _, attrname = name.rpartition(".")
+            submod = gm.get_submodule(modname)
+            setattr(submod, attrname, nn.Parameter(new_weight, requires_grad=False))
+
+            # Register new scale buffers
+            for scale_name, scale_val in quant_impl.default_scales(orig_weight.shape).items():
+                submod.register_buffer(scale_name, scale_val)
+
+            # Register load hook
+            gm._register_load_state_dict_pre_hook(partial(quant_impl.load_hook, weight_name=name))
+
+            # Create get_attr nodes for new param and each scale
+            with gm.graph.inserting_before(node):
+                new_weight_attr = gm.graph.get_attr(name)
+                new_attrs.append(new_weight_attr)
+                scales = [gm.graph.get_attr(modname + "." + s) for s in scale_keys]
+                scale_nodes_group.append(scales)
+
+        return new_attrs, scale_nodes_group
+
+    # Quantize all three expert weights
+    w1_attrs, w1_scales = quantize_param_list(w1_names)
+    w2_attrs, w2_scales = quantize_param_list(w2_names)
+    w3_attrs, w3_scales = quantize_param_list(w3_names)
+
+    # Collect scale tensors per scale type across w1, w2, w3
+    def collect_scales(index: int) -> Tuple[List[Node], List[Node], List[Node]]:
+        return (
+            [s[index] for s in w1_scales],
+            [s[index] for s in w2_scales],
+            [s[index] for s in w3_scales],
+        )
+
+    # Prepare args
+    args = [
+        node.args[0],  # x
+        node.args[1],  # selected_experts
+        node.args[2],  # routing_weights
+        w1_attrs,
+        w2_attrs,
+        w3_attrs,
+    ]
+
+    for idx in range(len(scale_keys)):
+        s1, s2, s3 = collect_scales(idx)
+        args.extend([s1, s2, s3])
+
+    # Replace the current node with the quantized version
+    with gm.graph.inserting_after(node):
+        new_node = gm.graph.call_function(
+            quantized_op,
+            args=tuple(args),
+        )
+        print(f"updating {node.name} args, ", new_node.args)
+        node.replace_all_uses_with(new_node)
+        gm.graph.erase_node(node)
+
+
+def quantize_moe(gm: GraphModule, quant_config: Dict[str, Any]) -> None:
+    """
+    Traverse gm, find every torch.ops.auto_deploy.torch_moe, and replace it with the
+    quantized version using the quant_algo from quant_config.
+    """
+    quant_algo = quant_config.get("quant_algo")
+    if not quant_algo:
+        ad_logger.info("No quantization to do.")
+        return gm
+    excluded_patterns = quant_config.get("exclude_modules", [])
+
+    quant_impl = QuantizationImpl.create(quant_algo)
+    quantized_op = quantized_moe_op_map[quant_algo]
+
+    count = 0
+
+    for node in list(gm.graph.nodes):
+        if is_op(node, torch.ops.auto_deploy.torch_moe):
+            # Check that all expert weights should be quantized
+            w1_names, w2_names, w3_names = _extract_moe_weight_param_lists(node)
+            if any(
+                should_skip_quantization(n, excluded_patterns)
+                for n in w1_names + w2_names + w3_names
+            ):
+                continue
+            _quantize_moe_node(gm, node, quant_impl, quantized_op)
+            count += 1
+
+    if count == 0:
+        return gm
+
+    gm = canonicalize_graph(gm)
+    ad_logger.info(f"Found {count} {quant_algo} quantized {quantized_op} nodes.")
+    return
+
+
+# TODO(Fridah-nv): robust handling similar to `extract_param_names_from_lin_node` or expand it
+def _extract_moe_weight_param_lists(moe_node: Node) -> Tuple[List[str], List[str], List[str]]:
+    """
+    Given a torch.ops.moe.torch_moe node in gm.graph, extract three lists of
+    the parameter names for w1_weight, w2_weight, and w3_weight.
+
+    Returns:
+      (w1_names, w2_names, w3_names), each a list of strings like 'layer.expert_0.w1.weight'
+    """
+    # args layout: (x, selected_experts, routing_weights, w1_list, w2_list, w3_list)
+    try:
+        w1_list, w2_list, w3_list = moe_node.args[3:6]
+    except ValueError:
+        raise RuntimeError(
+            f"Expected moe_node.args to have at least 6 entries, got {len(moe_node.args)}"
+        )
+
+    def _unwrap_list(arg) -> List[str]:
+        if not isinstance(arg, (list, tuple)):
+            raise TypeError(f"Expected a Python list/tuple of get_attr Nodes, got {type(arg)}")
+        names: List[str] = []
+        for elt in arg:
+            if not isinstance(elt, Node) or elt.op != "get_attr":
+                raise RuntimeError(f"Expected each list element to be a get_attr Node, got {elt}")
+            names.append(elt.target)
+        return names
+
+    w1_names = _unwrap_list(w1_list)
+    w2_names = _unwrap_list(w2_list)
+    w3_names = _unwrap_list(w3_list)
+
+    return w1_names, w2_names, w3_names

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/quantize_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/quantize_moe.py
@@ -92,7 +92,7 @@ def _quantize_moe_node(
             quantized_op,
             args=tuple(args),
         )
-        print(f"updating {node.name} args, ", new_node.args)
+        ad_logger.debug(f"Updating {node.name} args to {new_node.args}")
         node.replace_all_uses_with(new_node)
         gm.graph.erase_node(node)
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -32,6 +32,7 @@ from .library import (
     match_rope_pattern,
     optimize_rope,
     quantize,
+    quantize_moe,
     resize_kv_cache,
     update_in_out_nodes,
 )
@@ -77,6 +78,7 @@ class InferenceOptimizer:
 
         # quantization
         quantize(egm, self.factory.get_quant_config())
+        quantize_moe(egm, self.factory.get_quant_config())
 
         # Match MoE pattern
         match_moe_pattern(egm)

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -148,8 +148,8 @@ def extract_param_names_from_lin_node(mm_node: Node) -> Tuple[str, Optional[str]
     Args:
         mm_node: Matmul node in the graph.
     """
-    assert is_linear_op(mm_node, include_quantization=True), (
-        f"Expecting linear node, Found: {mm_node}"
+    assert is_linear_op(mm_node, include_quantization=True) or is_bmm_op(mm_node), (
+        f"Expecting linear or bmm node, Found: {mm_node}"
     )
     weight_node = extract_weight_node(mm_node)
 

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -116,8 +116,6 @@ def extract_weight_node(mm_node: Node) -> int:
         allowed_ops = {
             torch.ops.aten.to.dtype,
             torch.ops.aten.view.default,
-            # there could be torch_linear_simple.default between BMM node and the weight node
-            torch.ops.auto_deploy.torch_quant_fp8_linear,
         }
 
         if node.op == "get_attr":

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -106,19 +106,6 @@ def get_quantization_params_from_linear_node(linear_op: torch.fx.node.Node):
     return input_params, weight_params, output_params
 
 
-def is_match(node: Node, names_to_skip: List[str]):
-    if names_to_skip is None:
-        return False
-    for n in names_to_skip:
-        module_stack = node.meta.get("nn_module_stack", None)
-        if module_stack is None:
-            return False
-        module_stack = list(module_stack.keys())
-        if n in module_stack[-1]:
-            return True
-    return False
-
-
 def extract_weight_node(mm_node: Node) -> int:
     """Extracts the weight node from the given matmul node."""
 

--- a/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
@@ -330,11 +330,15 @@ class FP4QuantizationImpl(QuantizationImpl):
     def shard_load_hook(
         state_dict, prefix, *args, weight_name, weight_shape, dim, rank, world_size
     ):
-        if weight_name + "_scale" in state_dict:
-            weight_scale = state_dict[weight_name + "_scale"]
-            state_dict[weight_name + "_scale"] = _shard_fp4_weight_scale(
-                weight_scale, weight_shape, dim, rank, world_size
-            )
+        try:
+            if weight_name + "_scale" in state_dict:
+                weight_scale = state_dict[weight_name + "_scale"]
+                state_dict[weight_name + "_scale"] = _shard_fp4_weight_scale(
+                    weight_scale, weight_shape, dim, rank, world_size
+                )
+        except Exception as e:
+            print(f"[shard_load_hook] Skipped due to exception: {e}", flush=True)
+
 
     @staticmethod
     def fuse_linear_weights(

--- a/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
@@ -20,7 +20,7 @@ from .node_utils import (
 )
 
 try:
-    from ...quantization.utils import float4_sf_dtype
+    from tensorrt_llm.quantization.utils.fp4_utils import float4_sf_dtype
 except ImportError:
     float4_sf_dtype = None
 

--- a/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
@@ -466,12 +466,19 @@ class FP8BMMQuantizationImpl(QuantizationImpl):
                         )
 
 
-def should_skip_quantization(node: Node, excluded_patterns: List[str]) -> bool:
-    """Check if a node is a non-quantized linear op that matches any excluded pattern."""
-    if not is_linear_op(node, include_quantization=False):
-        return True
-    param_name, _ = extract_param_names_from_lin_node(node)
-    modname, _, _ = param_name.rpartition(".")
+def should_skip_quantization(
+    node_or_name: Union[Node, str],
+    excluded_patterns: list[str],
+) -> bool:
+    """Check if a node or parameter name should be skipped based on excluded patterns."""
+    if isinstance(node_or_name, str):
+        modname, _, _ = node_or_name.rpartition(".")
+    else:
+        if not is_linear_op(node_or_name, include_quantization=False):
+            return True
+        param_name, _ = extract_param_names_from_lin_node(node_or_name)
+        modname, _, _ = param_name.rpartition(".")
+
     return any(fnmatch(modname, pattern) for pattern in excluded_patterns)
 
 

--- a/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
@@ -85,6 +85,7 @@ class QuantizationImpl:
                 quantization_impl_map = {
                     "": None,
                     "FP8": FP8QuantizationImpl,
+                    "NVFP4": FP4QuantizationImpl,
                 }
             return quantization_impl_map[quant_type_or_node]
 
@@ -463,6 +464,8 @@ class FP8BMMQuantizationImpl(QuantizationImpl):
                             attr_name,
                             torch.nn.Parameter(param_cm, requires_grad=param.requires_grad),
                         )
+
+
 def should_skip_quantization(node: Node, excluded_patterns: List[str]) -> bool:
     """Check if a node is a non-quantized linear op that matches any excluded pattern."""
     if not is_linear_op(node, include_quantization=False):

--- a/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
@@ -22,7 +22,7 @@ from .node_utils import (
 )
 
 try:
-    from tensorrt_llm.quantization.utils.fp4_utils import float4_sf_dtype
+    from ....quantization.utils.fp4_utils import float4_sf_dtype
 except ImportError:
     float4_sf_dtype = None
 

--- a/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
@@ -477,13 +477,8 @@ def should_skip_quantization(
     else:
         if not (is_linear_op(node_or_name, include_quantization=False) or is_bmm_op(node_or_name)):
             return True
-        try:
-            param_name, _ = extract_param_names_from_lin_node(node_or_name)
-            modname, _, _ = param_name.rpartition(".")
-        except Exception:
-            # Cannot trace parameter — likely a dynamic tensor.
-            # Assume it’s not explicitly excluded and allow quantization to proceed.
-            return False
+        param_name, _ = extract_param_names_from_lin_node(node_or_name)
+        modname, _, _ = param_name.rpartition(".")
 
     return any(fnmatch(modname, pattern) for pattern in excluded_patterns)
 

--- a/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
@@ -339,7 +339,6 @@ class FP4QuantizationImpl(QuantizationImpl):
         except Exception as e:
             print(f"[shard_load_hook] Skipped due to exception: {e}", flush=True)
 
-
     @staticmethod
     def fuse_linear_weights(
         weights, weight_scale, alpha, input_scale

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
@@ -242,31 +242,15 @@ class BMMDynamicModel(nn.Module):
         self.hidden_dim = hidden_dim
         self.batch_size = batch_size
         # Create a linear layer to generate dynamic weights
-        self.experts = nn.ModuleList(
-            [nn.Linear(hidden_dim, hidden_dim * hidden_dim) for _ in range(2)]
-        )
+        self.weight = nn.Parameter(torch.randn(batch_size, hidden_dim * hidden_dim))
 
     def forward(self, x):
         # x shape: [batch_size, seq_len, hidden_dim]
         batch_size, seq_len, hidden_dim = x.shape
 
         # Generate dynamic weights from input
-        # Take mean across sequence dimension to get [batch_size, hidden_dim]
-        weight_input = x.mean(dim=1)  # [batch_size, hidden_dim]
-
-        # Generate weights: [batch_size, hidden_dim * hidden_dim]
-        weight_flat_1 = self.experts[0](weight_input)
-        weight_flat_2 = self.experts[1](weight_input)
-
-        # Reshape to BMM weight format: [batch_size, hidden_dim, hidden_dim]
-        dynamic_weights_1 = weight_flat_1.view(batch_size, hidden_dim, hidden_dim)
-        dynamic_weights_2 = weight_flat_2.view(batch_size, hidden_dim, hidden_dim)
-
-        # Perform BMM with dynamic weights
-        out0 = torch.bmm(x, dynamic_weights_1)
-        out1 = torch.bmm(x, dynamic_weights_2)
-
-        return torch.cat([out0, out1], dim=2)
+        dynamic_weights = self.weight.view(batch_size, hidden_dim, hidden_dim)
+        return torch.bmm(x, dynamic_weights)
 
 
 def generate_dynamic_shapes(max_batch_size, max_seq_len):

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
@@ -4,14 +4,16 @@ import sys
 import pytest
 import torch
 import torch.nn.functional as F
-from _torch_test_utils import fp8_compatible, fp4_compatible, trtllm_ops_available
+from _torch_test_utils import fp4_compatible, fp8_compatible, trtllm_ops_available
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 from tensorrt_llm._torch.modules.fused_moe import MoE  # noqa: F401
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../../../../"))
 from helpers import reference_moe_torch
+
 from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import fp4_global_scale
+
 
 def setup_moe_test(dtype, num_experts):
     SEQ_LEN = 8
@@ -269,9 +271,7 @@ def test_fp4_moe_op_run(dtype):
             w2_alpha,
             w3_alpha,
         )
-        ref_output = reference_moe_torch(
-            x, selected_experts, final_scales, num_experts, weights
-        )
+        ref_output = reference_moe_torch(x, selected_experts, final_scales, num_experts, weights)
 
     torch.cuda.synchronize()
     rtol, atol = 1.5, 1.0

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
@@ -22,9 +22,9 @@ def setup_moe_test(dtype, num_experts):
     NUM_EXPERTS = num_experts
     TOP_K = 2
 
-    torch.manual_seed(0)
-    torch.cuda.manual_seed(0)
-    x = torch.randn((SEQ_LEN, HIDDEN_SIZE), dtype=dtype).cuda() * 0.5
+    torch.manual_seed(1234)
+    torch.cuda.manual_seed(1234)  # seed=0 will fail
+    x = torch.rand(SEQ_LEN, HIDDEN_SIZE, dtype=dtype).cuda() * 0.1
 
     router_logits = torch.randn((SEQ_LEN, NUM_EXPERTS), dtype=torch.float32).cuda()
     routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
@@ -40,9 +40,9 @@ def setup_moe_test(dtype, num_experts):
     fused_w2_weight = torch.empty((NUM_EXPERTS, HIDDEN_SIZE, INTERMEDIATE_SIZE), dtype=dtype).cuda()
 
     for expert_id in range(NUM_EXPERTS):
-        w1 = torch.randn((INTERMEDIATE_SIZE, HIDDEN_SIZE), dtype=dtype).cuda() * 0.5
-        w2 = torch.randn((HIDDEN_SIZE, INTERMEDIATE_SIZE), dtype=dtype).cuda() * 0.5
-        w3 = torch.randn((INTERMEDIATE_SIZE, HIDDEN_SIZE), dtype=dtype).cuda() * 0.5
+        w1 = torch.rand(INTERMEDIATE_SIZE, HIDDEN_SIZE, dtype=dtype).cuda() * 0.1
+        w2 = torch.rand(HIDDEN_SIZE, INTERMEDIATE_SIZE, dtype=dtype).cuda() * 0.1
+        w3 = torch.rand(INTERMEDIATE_SIZE, HIDDEN_SIZE, dtype=dtype).cuda() * 0.1
 
         weights[f"{expert_id}.w1.weight"] = w1
         weights[f"{expert_id}.w2.weight"] = w2

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
@@ -132,7 +132,7 @@ def test_fp8_moe_op_run(dtype):
     ) = setup_moe_test(dtype, num_experts)
 
     with torch.inference_mode():
-        output_torch_moe = torch.ops.moe.torch_moe(
+        output_torch_moe = torch.ops.auto_deploy.torch_moe(
             x,
             selected_experts,
             final_scales,
@@ -163,7 +163,7 @@ def test_fp8_moe_op_run(dtype):
         fused_w2_weight[i] = (fused_w2_weight[i] / w2_weight_scale[i]).to(torch.float8_e4m3fn)
 
     with torch.inference_mode():
-        output_torch_fp8_moe = torch.ops.moe.torch_fp8_moe(
+        output_torch_fp8_moe = torch.ops.auto_deploy.torch_fp8_moe(
             x,
             selected_experts,
             final_scales,
@@ -206,7 +206,7 @@ def test_fp4_moe_op_run(dtype):
     ) = setup_moe_test(dtype, num_experts)
 
     with torch.inference_mode():
-        output_torch_moe = torch.ops.moe.torch_moe(
+        output_torch_moe = torch.ops.auto_deploy.torch_moe(
             x,
             selected_experts,
             final_scales,
@@ -254,7 +254,7 @@ def test_fp4_moe_op_run(dtype):
 
     # run FP4 MoE op
     with torch.inference_mode():
-        output_torch_fp4_moe = torch.ops.moe.torch_fp4_moe(
+        output_torch_fp4_moe = torch.ops.auto_deploy.torch_fp4_moe(
             x,
             selected_experts,
             final_scales,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
@@ -1,18 +1,23 @@
+import os
+import sys
+
 import pytest
 import torch
 import torch.nn.functional as F
-from _torch.helpers import reference_moe_torch
+from _torch_test_utils import fp8_compatible
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 from tensorrt_llm._torch.modules.fused_moe import MoE  # noqa: F401
 
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../../../"))
+from helpers import reference_moe_torch
 
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_moe_op_run(dtype):
+
+def setup_moe_test(dtype, num_experts):
     SEQ_LEN = 8
     HIDDEN_SIZE = 64
     INTERMEDIATE_SIZE = 32
-    NUM_EXPERTS = 3
+    NUM_EXPERTS = num_experts
     TOP_K = 2
 
     torch.manual_seed(0)
@@ -25,18 +30,18 @@ def test_moe_op_run(dtype):
     final_scales = final_scales / final_scales.sum(dim=-1, keepdim=True)
     final_scales = final_scales.to(x.dtype)
 
-    w1_weight = []
-    w2_weight = []
-    w3_weight = []
+    w1_weight, w2_weight, w3_weight = [], [], []
     weights = {}
     fused_w3_w1_stacked_weight = torch.empty(
         (NUM_EXPERTS, INTERMEDIATE_SIZE * 2, HIDDEN_SIZE), dtype=dtype
     ).cuda()
     fused_w2_weight = torch.empty((NUM_EXPERTS, HIDDEN_SIZE, INTERMEDIATE_SIZE), dtype=dtype).cuda()
+
     for expert_id in range(NUM_EXPERTS):
         w1 = torch.randn((INTERMEDIATE_SIZE, HIDDEN_SIZE), dtype=dtype).cuda() * 0.5
         w2 = torch.randn((HIDDEN_SIZE, INTERMEDIATE_SIZE), dtype=dtype).cuda() * 0.5
         w3 = torch.randn((INTERMEDIATE_SIZE, HIDDEN_SIZE), dtype=dtype).cuda() * 0.5
+
         weights[f"{expert_id}.w1.weight"] = w1
         weights[f"{expert_id}.w2.weight"] = w2
         weights[f"{expert_id}.w3.weight"] = w3
@@ -47,6 +52,34 @@ def test_moe_op_run(dtype):
 
         fused_w3_w1_stacked_weight.data[expert_id].copy_(torch.cat([w3, w1], dim=-2))
         fused_w2_weight.data[expert_id].copy_(w2)
+
+    return (
+        x,
+        selected_experts,
+        final_scales,
+        w1_weight,
+        w2_weight,
+        w3_weight,
+        weights,
+        fused_w3_w1_stacked_weight,
+        fused_w2_weight,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_moe_op_run(dtype):
+    num_experts = 3
+    (
+        x,
+        selected_experts,
+        final_scales,
+        w1_weight,
+        w2_weight,
+        w3_weight,
+        weights,
+        fused_w3_w1_stacked_weight,
+        fused_w2_weight,
+    ) = setup_moe_test(dtype, num_experts)
 
     with torch.inference_mode():
         output_torch_moe = torch.ops.auto_deploy.torch_moe(
@@ -71,11 +104,81 @@ def test_moe_op_run(dtype):
             fused_w3_w1_stacked_weight,
             fused_w2_weight,
         )
-
-        ref_output = reference_moe_torch(x, selected_experts, final_scales, NUM_EXPERTS, weights)
+        ref_output = reference_moe_torch(x, selected_experts, final_scales, num_experts, weights)
 
     torch.cuda.synchronize()
     torch.testing.assert_close(output_trt_fused_moe, output_torch_fused_moe, rtol=5e-2, atol=5e-2)
     torch.testing.assert_close(output_trt_fused_moe, ref_output, rtol=5e-2, atol=5e-2)
     torch.testing.assert_close(output_torch_fused_moe, ref_output, rtol=1e-5, atol=1e-5)
     torch.testing.assert_close(output_torch_moe, ref_output, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support")
+def test_fp8_moe_op_run(dtype):
+    num_experts = 3
+    (
+        x,
+        selected_experts,
+        final_scales,
+        w1_weight,
+        w2_weight,
+        w3_weight,
+        weights,
+        fused_w3_w1_stacked_weight,
+        fused_w2_weight,
+    ) = setup_moe_test(dtype, num_experts)
+
+    with torch.inference_mode():
+        output_torch_moe = torch.ops.moe.torch_moe(
+            x,
+            selected_experts,
+            final_scales,
+            w1_weight,
+            w2_weight,
+            w3_weight,
+        )
+
+    w1_input_scale, w2_input_scale, w3_input_scale = [], [], []
+    w1_weight_scale, w2_weight_scale, w3_weight_scale = [], [], []
+    for i in range(num_experts):
+        inp_scale_val = torch.tensor(1.0).float().cuda()
+        wt_scale_factor = 448 if dtype == torch.bfloat16 else 432  # float16 overflow with 448
+        wt_scale_val = (torch.max(torch.abs(w1_weight[i])) / wt_scale_factor).float().to("cuda")
+        w1_input_scale.append(inp_scale_val)
+        w2_input_scale.append(inp_scale_val)
+        w3_input_scale.append(inp_scale_val)
+        w1_weight_scale.append(wt_scale_val)
+        w2_weight_scale.append(wt_scale_val)
+        w3_weight_scale.append(wt_scale_val)
+        # Cast the expert weight tensors and fused weights to FP8.
+        w1_weight[i] = (w1_weight[i] / w1_weight_scale[i]).to(torch.float8_e4m3fn)
+        w2_weight[i] = (w2_weight[i] / w2_weight_scale[i]).to(torch.float8_e4m3fn)
+        w3_weight[i] = (w3_weight[i] / w3_weight_scale[i]).to(torch.float8_e4m3fn)
+        fused_w3_w1_stacked_weight[i] = (fused_w3_w1_stacked_weight[i] / w1_weight_scale[i]).to(
+            torch.float8_e4m3fn
+        )
+        fused_w2_weight[i] = (fused_w2_weight[i] / w2_weight_scale[i]).to(torch.float8_e4m3fn)
+
+    with torch.inference_mode():
+        output_torch_fp8_moe = torch.ops.moe.torch_fp8_moe(
+            x,
+            selected_experts,
+            final_scales,
+            w1_weight,
+            w2_weight,
+            w3_weight,
+            w1_input_scale,
+            w2_input_scale,
+            w3_input_scale,
+            w1_weight_scale,
+            w2_weight_scale,
+            w3_weight_scale,
+        )
+        ref_output = reference_moe_torch(x, selected_experts, final_scales, num_experts, weights)
+
+    torch.cuda.synchronize()
+    rtol = 0.5 if dtype == torch.bfloat16 else 1.5
+    atol = 0.8 if dtype == torch.bfloat16 else 1
+    torch.testing.assert_close(output_torch_fp8_moe, output_torch_moe, rtol=rtol, atol=atol)
+    torch.testing.assert_close(output_torch_fp8_moe, ref_output, rtol=rtol, atol=atol)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
@@ -1,18 +1,12 @@
-import os
-import sys
-
 import pytest
 import torch
 import torch.nn.functional as F
+from _torch.helpers import reference_moe_torch
 from _torch_test_utils import fp4_compatible, fp8_compatible, trtllm_ops_available
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
-from tensorrt_llm._torch.modules.fused_moe import MoE  # noqa: F401
-
-sys.path.append(os.path.join(os.path.dirname(__file__), "../../../../"))
-from helpers import reference_moe_torch
-
 from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import fp4_global_scale
+from tensorrt_llm._torch.modules.fused_moe import MoE  # noqa: F401
 
 
 def setup_moe_test(dtype, num_experts):
@@ -163,7 +157,7 @@ def test_fp8_moe_op_run(dtype):
         fused_w2_weight[i] = (fused_w2_weight[i] / w2_weight_scale[i]).to(torch.float8_e4m3fn)
 
     with torch.inference_mode():
-        output_torch_fp8_moe = torch.ops.auto_deploy.torch_fp8_moe(
+        output_torch_fp8_moe = torch.ops.auto_deploy.torch_quant_fp8_moe(
             x,
             selected_experts,
             final_scales,
@@ -254,7 +248,7 @@ def test_fp4_moe_op_run(dtype):
 
     # run FP4 MoE op
     with torch.inference_mode():
-        output_torch_fp4_moe = torch.ops.auto_deploy.torch_fp4_moe(
+        output_torch_fp4_moe = torch.ops.auto_deploy.torch_quant_fp4_moe(
             x,
             selected_experts,
             final_scales,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
@@ -63,14 +63,14 @@ class BlockSparseTop2MLPFP8(nn.Module):
 
     def forward(self, hidden_states: torch.Tensor):
         x = hidden_states
-        w1_out = torch.ops.quant.fp8_linear(
+        w1_out = torch.ops.auto_deploy.torch_quant_fp8_linear(
             x,
             self.w1_fp8,
             bias=None,
             input_scale=self.inp_scale,
             weight_scale=self.w1_scale,
         )
-        w3_out = torch.ops.quant.fp8_linear(
+        w3_out = torch.ops.auto_deploy.torch_quant_fp8_linear(
             x,
             self.w3_fp8,
             bias=None,
@@ -78,7 +78,7 @@ class BlockSparseTop2MLPFP8(nn.Module):
             weight_scale=self.w3_scale,
         )
         fused = self.act_fn(w1_out) * w3_out
-        out = torch.ops.quant.fp8_linear(
+        out = torch.ops.auto_deploy.torch_quant_fp8_linear(
             fused,
             self.w2_fp8,
             bias=None,
@@ -174,7 +174,7 @@ class MoEPatternModel(nn.Module):
     "use_fp8,expected_op,skip",
     [
         pytest.param(False, torch.ops.auto_deploy.torch_moe, False, id="simple"),
-        pytest.param(True, torch.ops.moe.torch_fp8_moe, not fp8_compatible(), id="fp8"),
+        pytest.param(True, torch.ops.auto_deploy.torch_fp8_moe, not fp8_compatible(), id="fp8"),
     ],
 )
 def test_moe_matching(use_fp8, expected_op, skip):

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
@@ -1,8 +1,10 @@
+import pytest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from _graph_test_helpers import run_test
 from _model_test_utils import MoEOpModel
+from _torch_test_utils import fp8_compatible
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 from tensorrt_llm._torch.auto_deploy.transformations.library.fused_moe import (
@@ -30,17 +32,89 @@ class BlockSparseTop2MLP(nn.Module):
         return current_hidden_states
 
 
+class BlockSparseTop2MLPFP8(nn.Module):
+    def __init__(self, ffn_dim, hidden_dim, dtype=torch.bfloat16, device="cuda"):
+        super().__init__()
+        self.ffn_dim = ffn_dim
+        self.hidden_dim = hidden_dim
+        # Input scale fixed to 1.0
+        self.register_buffer("inp_scale", torch.tensor(1.0, dtype=torch.float, device=device))
+        # FP8 weight scale factor depends on dtype
+        wt_factor = 448 if dtype == torch.bfloat16 else 432
+
+        w1_fp32 = torch.randn(ffn_dim, hidden_dim, device=device)
+        w3_fp32 = torch.randn(ffn_dim, hidden_dim, device=device)
+        w2_fp32 = torch.randn(hidden_dim, ffn_dim, device=device)
+        w1_scale = (w1_fp32.abs().max() / wt_factor).float().to(device)
+        w3_scale = (w3_fp32.abs().max() / wt_factor).float().to(device)
+        w2_scale = (w2_fp32.abs().max() / wt_factor).float().to(device)
+
+        self.register_buffer("w1_scale", w1_scale)
+        self.register_buffer("w3_scale", w3_scale)
+        self.register_buffer("w2_scale", w2_scale)
+
+        w1_fp8 = (w1_fp32 / w1_scale).to(torch.float8_e4m3fn)
+        w3_fp8 = (w3_fp32 / w3_scale).to(torch.float8_e4m3fn)
+        w2_fp8 = (w2_fp32 / w2_scale).to(torch.float8_e4m3fn)
+        self.register_parameter("w1_fp8", nn.Parameter(w1_fp8))
+        self.register_parameter("w3_fp8", nn.Parameter(w3_fp8))
+        self.register_parameter("w2_fp8", nn.Parameter(w2_fp8))
+        self.act_fn = F.silu
+
+    def forward(self, hidden_states: torch.Tensor):
+        x = hidden_states
+        w1_out = torch.ops.quant.fp8_linear(
+            x,
+            self.w1_fp8,
+            bias=None,
+            input_scale=self.inp_scale,
+            weight_scale=self.w1_scale,
+        )
+        w3_out = torch.ops.quant.fp8_linear(
+            x,
+            self.w3_fp8,
+            bias=None,
+            input_scale=self.inp_scale,
+            weight_scale=self.w3_scale,
+        )
+        fused = self.act_fn(w1_out) * w3_out
+        out = torch.ops.quant.fp8_linear(
+            fused,
+            self.w2_fp8,
+            bias=None,
+            input_scale=self.inp_scale,
+            weight_scale=self.w2_scale,
+        )
+        return out
+
+
 class BlockSparseMoE(nn.Module):
-    def __init__(self, hidden_size=32, num_experts=4, intermediate_size=16):
+    def __init__(
+        self,
+        hidden_size=32,
+        num_experts=4,
+        intermediate_size=16,
+        use_fp8: bool = False,
+        dtype=torch.bfloat16,
+        device="cuda",
+    ):
         super().__init__()
         self.hidden_size = hidden_size
         self.num_experts = num_experts
-        self.intermediate_size = intermediate_size
         self.top_k = 2
-        self.gate = nn.Linear(hidden_size, num_experts)
-        self.experts = nn.ModuleList(
-            [BlockSparseTop2MLP(intermediate_size, hidden_size) for _ in range(num_experts)]
-        )
+        self.gate = nn.Linear(hidden_size, num_experts, bias=False).to(device=device, dtype=dtype)
+        expert_cls = BlockSparseTop2MLPFP8 if use_fp8 else BlockSparseTop2MLP
+        if use_fp8:
+            self.experts = nn.ModuleList(
+                [
+                    expert_cls(intermediate_size, hidden_size, dtype, device)
+                    for _ in range(num_experts)
+                ]
+            )
+        else:
+            self.experts = nn.ModuleList(
+                [expert_cls(intermediate_size, hidden_size) for _ in range(num_experts)]
+            )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         batch_size, sequence_length, hidden_dim = hidden_states.shape
@@ -75,10 +149,15 @@ class BlockSparseMoE(nn.Module):
 
 
 class MoEPatternModel(nn.Module):
-    def __init__(self):
+    def __init__(self, use_fp8: bool = False):
         super().__init__()
         self.embedding = nn.Embedding(100, 32)
-        self.block_sparse_moe = BlockSparseMoE(hidden_size=32, num_experts=2, intermediate_size=16)
+        self.block_sparse_moe = BlockSparseMoE(
+            hidden_size=32,
+            num_experts=2,
+            intermediate_size=16,
+            use_fp8=use_fp8,
+        )
 
     def forward(self, x):
         embedded = F.embedding(x, self.embedding.weight)
@@ -91,19 +170,34 @@ class MoEPatternModel(nn.Module):
         return torch.randint(0, 100, (2, 10), device=device)
 
 
-def test_moe_matching():
+@pytest.mark.parametrize(
+    "use_fp8,expected_op,skip",
+    [
+        pytest.param(False, torch.ops.auto_deploy.torch_moe, False, id="simple"),
+        pytest.param(True, torch.ops.moe.torch_fp8_moe, not fp8_compatible(), id="fp8"),
+    ],
+)
+def test_moe_matching(use_fp8, expected_op, skip):
+    if skip:
+        pytest.skip("FP8 not supported on this hardware")
     device = "cuda"
-    model = MoEPatternModel().to(device=device, dtype=torch.bfloat16)
+
+    model = MoEPatternModel(use_fp8=use_fp8).to(device=device)
+    if not use_fp8:
+        model = model.to(dtype=torch.bfloat16)
+    else:
+        model.embedding = model.embedding.to(dtype=torch.bfloat16)
+        model.block_sparse_moe.gate = model.block_sparse_moe.gate.to(dtype=torch.bfloat16)
     x = model.get_input(device=device)
 
     _ = run_test(
         model,
         x,
         match_moe_pattern,
-        lambda gm: any(is_op(n, torch.ops.auto_deploy.torch_moe) for n in gm.graph.nodes),
-        lambda num_p_og: num_p_og,
-        atol=1e-3,
-        rtol=1e-3,
+        lambda gm: any(is_op(n, expected_op) for n in gm.graph.nodes),
+        lambda num: num,
+        atol=0.05 if use_fp8 else 1e-3,
+        rtol=0.01 if use_fp8 else 1e-3,
         test_load_hook=True,
         strict_loading=True,
     )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
@@ -171,15 +171,18 @@ class MoEPatternModel(nn.Module):
 
 
 @pytest.mark.parametrize(
-    "use_fp8,expected_op,skip",
+    "use_fp8,expected_op",
     [
-        pytest.param(False, torch.ops.auto_deploy.torch_moe, False, id="simple"),
-        pytest.param(True, torch.ops.auto_deploy.torch_fp8_moe, not fp8_compatible(), id="fp8"),
+        pytest.param(False, torch.ops.auto_deploy.torch_moe, id="simple"),
+        pytest.param(
+            True,
+            torch.ops.auto_deploy.torch_quant_fp8_moe,
+            marks=pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support"),
+            id="fp8",
+        ),
     ],
 )
-def test_moe_matching(use_fp8, expected_op, skip):
-    if skip:
-        pytest.skip("FP8 not supported on this hardware")
+def test_moe_matching(use_fp8, expected_op):
     device = "cuda"
 
     model = MoEPatternModel(use_fp8=use_fp8).to(device=device)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from _graph_test_helpers import run_test
 from _model_test_utils import MoEOpModel
-from _torch_test_utils import fp8_compatible
+from _torch_test_utils import fp4_compatible, fp8_compatible, trtllm_ops_available
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 from tensorrt_llm._torch.auto_deploy.transformations.library.fused_moe import (
@@ -12,6 +12,7 @@ from tensorrt_llm._torch.auto_deploy.transformations.library.fused_moe import (
     match_moe_pattern,
 )
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import fp4_global_scale
 
 
 class BlockSparseTop2MLP(nn.Module):
@@ -88,13 +89,105 @@ class BlockSparseTop2MLPFP8(nn.Module):
         return out
 
 
+class BlockSparseTop2MLPFP4(nn.Module):
+    def __init__(self, ffn_dim, hidden_dim, input_sample, dtype=torch.bfloat16, device="cuda"):
+        super().__init__()
+        self.ffn_dim = ffn_dim
+        self.hidden_dim = hidden_dim
+
+        # Prepare full-precision weights
+        w1_fp32 = torch.randn(ffn_dim, hidden_dim, device=device, dtype=dtype) * 0.01
+        w3_fp32 = torch.randn(ffn_dim, hidden_dim, device=device, dtype=dtype) * 0.01
+        w2_fp32 = torch.randn(hidden_dim, ffn_dim, device=device, dtype=dtype) * 0.01
+
+        # Compute input scale
+        inp_scale = fp4_global_scale(input_sample)
+
+        # Compute per-weight-layer scales (global scale, no per-vector partition here)
+        scale_1 = fp4_global_scale(w1_fp32)
+        scale_2 = fp4_global_scale(w2_fp32)
+        scale_3 = fp4_global_scale(w3_fp32)
+
+        # Quantize weights using fake quant op
+        w1_fp4, w1_weight_scale = torch.ops.trtllm.fp4_quantize(w1_fp32, scale_1, 16, False)
+        w2_fp4, w2_weight_scale = torch.ops.trtllm.fp4_quantize(w2_fp32, scale_2, 16, False)
+        w3_fp4, w3_weight_scale = torch.ops.trtllm.fp4_quantize(w3_fp32, scale_3, 16, False)
+
+        # Compute alpha = 1 / (input_scale * weight_scale)
+        alpha_1 = 1.0 / (inp_scale * scale_1)
+        alpha_2 = 1.0 / (inp_scale * scale_2)
+        alpha_3 = 1.0 / (inp_scale * scale_3)
+
+        # Register all quantized tensors and metadata
+        self.register_parameter("w1_fp4", nn.Parameter(w1_fp4, requires_grad=False))
+        self.register_parameter("w2_fp4", nn.Parameter(w2_fp4, requires_grad=False))
+        self.register_parameter("w3_fp4", nn.Parameter(w3_fp4, requires_grad=False))
+
+        self.register_buffer("input_scale", inp_scale)
+        self.register_buffer("w1_weight_scale", w1_weight_scale)
+        self.register_buffer("w2_weight_scale", w2_weight_scale)
+        self.register_buffer("w3_weight_scale", w3_weight_scale)
+
+        self.register_buffer("w1_alpha", alpha_1)
+        self.register_buffer("w2_alpha", alpha_2)
+        self.register_buffer("w3_alpha", alpha_3)
+
+        self.act_fn = F.silu
+
+    def forward(self, hidden_states):
+        x = hidden_states
+        w1_out = torch.ops.auto_deploy.torch_quant_fp4_linear(
+            x,
+            self.w1_fp4,
+            bias=None,
+            input_scale=self.input_scale,
+            weight_scale=self.w1_weight_scale,
+            alpha=self.w1_alpha,
+        )
+        w3_out = torch.ops.auto_deploy.torch_quant_fp4_linear(
+            x,
+            self.w3_fp4,
+            bias=None,
+            input_scale=self.input_scale,
+            weight_scale=self.w3_weight_scale,
+            alpha=self.w3_alpha,
+        )
+        fused = self.act_fn(w1_out) * w3_out
+        out = torch.ops.auto_deploy.torch_quant_fp4_linear(
+            fused,
+            self.w2_fp4,
+            bias=None,
+            input_scale=self.input_scale,
+            weight_scale=self.w2_weight_scale,
+            alpha=self.w2_alpha,
+        )
+        return out
+
+
+def make_mlp_block(
+    quant_type: str,
+    ffn_dim: int,
+    hidden_dim: int,
+    input_sample: None,
+    dtype=torch.bfloat16,
+    device="cuda",
+):
+    if quant_type == "FP8":
+        return BlockSparseTop2MLPFP8(ffn_dim, hidden_dim, dtype=dtype, device=device)
+    elif quant_type == "NVFP4":
+        return BlockSparseTop2MLPFP4(ffn_dim, hidden_dim, input_sample, dtype=dtype, device=device)
+    else:
+        return BlockSparseTop2MLP(ffn_dim, hidden_dim)
+
+
 class BlockSparseMoE(nn.Module):
     def __init__(
         self,
-        hidden_size=32,
-        num_experts=4,
-        intermediate_size=16,
-        use_fp8: bool = False,
+        hidden_size=64,
+        num_experts=3,
+        intermediate_size=32,
+        quant_type="",
+        input_sample=None,
         dtype=torch.bfloat16,
         device="cuda",
     ):
@@ -103,18 +196,14 @@ class BlockSparseMoE(nn.Module):
         self.num_experts = num_experts
         self.top_k = 2
         self.gate = nn.Linear(hidden_size, num_experts, bias=False).to(device=device, dtype=dtype)
-        expert_cls = BlockSparseTop2MLPFP8 if use_fp8 else BlockSparseTop2MLP
-        if use_fp8:
-            self.experts = nn.ModuleList(
-                [
-                    expert_cls(intermediate_size, hidden_size, dtype, device)
-                    for _ in range(num_experts)
-                ]
-            )
-        else:
-            self.experts = nn.ModuleList(
-                [expert_cls(intermediate_size, hidden_size) for _ in range(num_experts)]
-            )
+        self.experts = nn.ModuleList(
+            [
+                make_mlp_block(
+                    quant_type, intermediate_size, hidden_size, input_sample, dtype, device
+                )
+                for _ in range(num_experts)
+            ]
+        )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         batch_size, sequence_length, hidden_dim = hidden_states.shape
@@ -149,14 +238,17 @@ class BlockSparseMoE(nn.Module):
 
 
 class MoEPatternModel(nn.Module):
-    def __init__(self, use_fp8: bool = False):
+    def __init__(self, quant_type: str = ""):
         super().__init__()
-        self.embedding = nn.Embedding(100, 32)
+        self.embedding = nn.Embedding(1000, 64)
+        input_ids = self.get_input(device="cpu")  # or pass as constructor arg
+        input_sample = self.embedding(input_ids)
         self.block_sparse_moe = BlockSparseMoE(
-            hidden_size=32,
-            num_experts=2,
-            intermediate_size=16,
-            use_fp8=use_fp8,
+            hidden_size=64,
+            num_experts=3,
+            intermediate_size=32,
+            quant_type=quant_type,
+            input_sample=input_sample,
         )
 
     def forward(self, x):
@@ -167,43 +259,60 @@ class MoEPatternModel(nn.Module):
         return hidden_states
 
     def get_input(self, device):
-        return torch.randint(0, 100, (2, 10), device=device)
+        torch.manual_seed(2345)
+        return torch.randint(0, 1000, (2, 2), device=device)
 
 
 @pytest.mark.parametrize(
-    "use_fp8,expected_op",
+    "quant_type,expected_op,atol,rtol",
     [
-        pytest.param(False, torch.ops.auto_deploy.torch_moe, id="simple"),
+        pytest.param("", torch.ops.auto_deploy.torch_moe, 1e-3, 1e-3, id="simple"),
         pytest.param(
-            True,
+            "FP8",
             torch.ops.auto_deploy.torch_quant_fp8_moe,
-            marks=pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support"),
+            0.05,
+            0.01,
+            marks=pytest.mark.skipif(not fp8_compatible(), reason="Requires FP8 support"),
             id="fp8",
+        ),
+        pytest.param(
+            "NVFP4",
+            torch.ops.auto_deploy.torch_quant_fp4_moe,
+            0.05,
+            0.01,
+            marks=pytest.mark.skipif(
+                not fp4_compatible() or not trtllm_ops_available(),
+                reason="Requires FP4 + TRTLLM support",
+            ),
+            id="fp4",
         ),
     ],
 )
-def test_moe_matching(use_fp8, expected_op):
-    device = "cuda"
+def test_moe_matching(quant_type, expected_op, atol, rtol):
+    with torch.inference_mode():
+        device = "cuda"
+        torch.manual_seed(2345)
+        model = MoEPatternModel(quant_type=quant_type).to(device=device)
 
-    model = MoEPatternModel(use_fp8=use_fp8).to(device=device)
-    if not use_fp8:
-        model = model.to(dtype=torch.bfloat16)
-    else:
-        model.embedding = model.embedding.to(dtype=torch.bfloat16)
-        model.block_sparse_moe.gate = model.block_sparse_moe.gate.to(dtype=torch.bfloat16)
-    x = model.get_input(device=device)
+        if quant_type == "":
+            model = model.to(dtype=torch.bfloat16)
+        else:
+            model.embedding = model.embedding.to(dtype=torch.bfloat16)
+            model.block_sparse_moe.gate = model.block_sparse_moe.gate.to(dtype=torch.bfloat16)
 
-    _ = run_test(
-        model,
-        x,
-        match_moe_pattern,
-        lambda gm: any(is_op(n, expected_op) for n in gm.graph.nodes),
-        lambda num: num,
-        atol=0.05 if use_fp8 else 1e-3,
-        rtol=0.01 if use_fp8 else 1e-3,
-        test_load_hook=True,
-        strict_loading=True,
-    )
+        x = model.get_input(device=device)
+
+        _ = run_test(
+            model,
+            x,
+            match_moe_pattern,
+            lambda gm: any(is_op(n, expected_op) for n in gm.graph.nodes),
+            lambda num: num,
+            atol=atol,
+            rtol=rtol,
+            test_load_hook=True,
+            strict_loading=True,
+        )
 
 
 def test_moe_fusion():

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quant_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quant_moe.py
@@ -1,0 +1,76 @@
+import pytest
+import torch
+from _graph_test_helpers import run_test
+from _model_test_utils import MoEOpModel
+from _torch_test_utils import fp4_compatible, fp8_compatible, trtllm_ops_available
+
+from tensorrt_llm._torch.auto_deploy.transformations.library import quantize_moe
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+
+
+@pytest.mark.parametrize(
+    "quant_algo, expected_op",
+    [
+        pytest.param(
+            "FP8",
+            torch.ops.auto_deploy.torch_quant_fp8_moe,
+            marks=pytest.mark.skipif(not fp8_compatible(), reason="Requires FP8"),
+        ),
+        pytest.param(
+            "NVFP4",
+            torch.ops.auto_deploy.torch_quant_fp4_moe,
+            marks=pytest.mark.skipif(
+                not (fp4_compatible() and trtllm_ops_available()), reason="Requires FP4 + TRTLLM"
+            ),
+        ),
+    ],
+)
+def test_quantize_moe_transformation(quant_algo, expected_op):
+    device = "cuda"
+    hidden_size = 64
+    intermediate_size = 32
+    num_experts = 3
+    top_k = 2
+
+    model = MoEOpModel(
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        top_k=top_k,
+    ).to(device=device, dtype=torch.bfloat16)
+
+    x = model.get_input(device=device, dtype=torch.bfloat16)
+
+    def _check_transformed_graph(gm):
+        return any(is_op(n, expected_op) for n in gm.graph.nodes)
+
+    def _expected_num_params(n):
+        """
+        Return expected parameter count after quantization.
+        For FP4, weights are quantized to half-size (simulate 4-bit).
+        """
+        # gate: Linear(hidden_size, num_experts)
+        gate_params = (hidden_size + 1) * num_experts  # with bias
+
+        if quant_algo == "NVFP4":
+            expert_params = num_experts * 3 * hidden_size * intermediate_size // 2
+            return gate_params + expert_params
+        else:
+            return n
+
+    quant_config = {"quant_algo": quant_algo}
+
+    def _transform(gm, *args):
+        return quantize_moe(gm, quant_config)
+
+    _ = run_test(
+        model=model,
+        x=x,
+        transform=_transform,
+        check_transformed_graph=_check_transformed_graph,
+        _get_expected_num_params=_expected_num_params,
+        atol=0.5,
+        rtol=0.5,
+        test_load_hook=False,
+        strict_loading=False,
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quant_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quant_moe.py
@@ -54,6 +54,8 @@ def test_quantize_moe_transformation(quant_algo, expected_op):
 
         if quant_algo == "NVFP4":
             expert_params = num_experts * 3 * hidden_size * intermediate_size // 2
+            # 3 weights per expert, of shape [hidden_size, intermediate_size] or
+            # [intermediate_size, hidden_size], shape will be halved to store quantized uint8 weight
             return gate_params + expert_params
         else:
             return n


### PR DESCRIPTION
## Description

Separate from https://github.com/NVIDIA/TensorRT-LLM/pull/4361

- [X]  update moe pattern matcher to handle fp8_linear in addition to linear. Also, add the corresponding torch_fp8_moe.
- [X]  Update FP4 for the same
- [X]  Update EP sharding with quantized ops
- [X]  Add quantize_moe pass for patched torch_moe ops for FP4 and FP8
- [X]  Add unit tests for custom ops and transformation pass

## Test Coverage

Tested e2e with `nvidia/Mixtral-8x7B-Instruct-v0.1-FP8` and `nvidia/Mixtral-8x7B-Instruct-v0.1-FP4` on B100, works with both world_size=1 and world_size=2
Note that the Mixtral models are now in patched moe path after the patch in [qwen3.py](https://github.com/nv-auto-deploy/TensorRT-LLM/blob/feat/ad-2025-07-07/tensorrt_llm/_torch/auto_deploy/models/qwen3.py)

`nvidia/DeepSeek-R1-FP4` only work with `full_state_dict` set to true in `load_checkpoint_in_model` (see [#5892](https://github.com/NVIDIA/TensorRT-LLM/issues/5892) ), but it also suffers from long execution time (I loaded the full model on 1 node and it took 3 hours to went through the pipeline and start loading weights). Verified that 4 layers can run e2e.

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
