### PR TITLE
[AutoDeploy] Refining AD configurability

### DIFF
--- a/examples/auto_deploy/README.md
+++ b/examples/auto_deploy/README.md
@@ -6,7 +6,7 @@
 
 <div align="left">
 
-AutoDeploy is designed to simplify and accelerate the deployment of PyTorch models, including off-the-shelf models like those from Hugging Face, to TensorRT-LLM. It automates graph transformations to integrate inference optimizations such as tensor parallelism, KV-caching and quantization. AutoDeploy supports optimized in-framework deployment, minimizing the amount of manual modification needed.
+AutoDeploy is an experimental feature in beta stage designed to simplify and accelerate the deployment of PyTorch models, including off-the-shelf models like those from Hugging Face, to TensorRT-LLM. It automates graph transformations to integrate inference optimizations such as tensor parallelism, KV-caching and quantization. AutoDeploy supports optimized in-framework deployment, minimizing the amount of manual modification needed.
 
 ______________________________________________________________________
 
@@ -146,7 +146,7 @@ Below is a non-exhaustive list of common config options:
 | `--args.skip-loading-weights` | Only load the architecture, not the weights |
 | `--args.model-kwargs` | Extra kwargs that are being passed to the model initializer in the model factory |
 | `--args.tokenizer-kwargs` | Extra kwargs that are being passed to the tokenizer initializer in the model factory |
-| `--args.world-size` | The number of GPUs for Tensor Parallel |
+| `--args.world-size` | The number of GPUs used for auto-sharding the model |
 | `--args.runtime` | Specifies which type of Engine to use during runtime (`"demollm"` or `"trtllm"`) |
 | `--args.compile-backend` | Specifies how to compile the graph at the end |
 | `--args.attn-backend` | Specifies kernel implementation for attention |
@@ -223,9 +223,6 @@ AutoDeploy can be seamlessly integrated into your existing workflows using TRT-L
 
 Here is an example of how you can build an LLM object with AutoDeploy integration:
 
-<details>
-<summary>Click to expand the example</summary>
-
 ```
 from tensorrt_llm._torch.auto_deploy import LLM
 
@@ -233,7 +230,7 @@ from tensorrt_llm._torch.auto_deploy import LLM
 # Construct the LLM high-level interface object with autodeploy as backend
 llm = LLM(
     model=<HF_MODEL_CARD_OR_DIR>,
-    world_size=<NUM_WORLD_RANK>,
+    world_size=<DESIRED_WORLD_SIZE>,
     compile_backend="torch-compile",
     model_kwargs={"num_hidden_layers": 2}, # test with smaller model configuration
     attn_backend="flashinfer", # choose between "triton" and "flashinfer"
@@ -249,28 +246,38 @@ llm = LLM(
 
 ```
 
+Please consult the [AutoDeploy `LLM` API](../../tensorrt_llm/_torch/auto_deploy/llm.py#L13) and the
+[`AutoDeployConfig` class](../../tensorrt_llm/_torch/auto_deploy/llm_args.py#L26)
+for more detail on how AutoDeploy is configured via the `**kwargs` of the `LLM` API.
+
+### Expert Configuration of LLM API
+
+For expert TensorRT-LLM users, we also expose the full set of [`LlmArgs`](../../tensorrt_llm/_torch/auto_deploy/llm_args.py#L201)
+*at your own risk*:
+
+<details>
+<summary>Click to expand for more details on using LlmArgs directly</summary>
+
+- All config fields that are used by the AutoDeploy core pipeline (i.e. the `InferenceOptimizer`) are
+  _exclusively_ exposed in the [`AutoDeployConfig` class](../../tensorrt_llm/_torch/auto_deploy/llm_args.py).
+  Please make sure to refer to those first.
+- For expert users we expose the full set of [`LlmArgs`](../../tensorrt_llm/_torch/auto_deploy/llm_args.py#L201)
+  that can be used to configure the [AutoDeploy `LLM` API](../../tensorrt_llm/_torch/auto_deploy/llm.py#L13) including runtime options.
+- Note that some fields in the full [`LlmArgs`](../../tensorrt_llm/_torch/auto_deploy/llm_args.py#L201)
+  object are overlapping, duplicated, and/or _ignored_ in AutoDeploy, particularly arguments
+  pertaining to configuring the model itself since AutoDeploy's model ingestion+optimize pipeline
+  significantly differs from the default manual workflow in TensorRT-LLM.
+- However, with the proper care the full [`LlmArgs`](../../tensorrt_llm/_torch/auto_deploy/llm_args.py#L201)
+  objects can be used to configure advanced runtime options in TensorRT-LLM.
+- Note that any valid field can be simply provided as keyword argument ("`**kwargs`") to the
+  [AutoDeploy `LLM` API](../../tensorrt_llm/_torch/auto_deploy/llm.py#L13).
+
 </details>
-
-For more examples on TRT-LLM LLM API, visit [`this page`](https://nvidia.github.io/TensorRT-LLM/examples/llm_api_examples.html).
-
-______________________________________________________________________
 
 ## Roadmap
 
-1. **Model Coverage:**
-
-   - Expand support for additional LLM variants and features:
-     - LoRA
-     - Speculative Decoding
-     - Model specialization for disaggregated serving
-
-1. **Performance Optimization:**
-
-   - Enhance inference speed and efficiency with:
-     - MoE fusion and all-reduce fusion techniques
-     - Reuse of TRT-LLM PyTorch operators for greater efficiency
-
-______________________________________________________________________
+Check out our [Github Project Board](https://github.com/orgs/NVIDIA/projects/83) to learn more about
+the current progress in AutoDeploy and where you can help.
 
 ## Disclaimer
 

--- a/examples/auto_deploy/README.md
+++ b/examples/auto_deploy/README.md
@@ -253,7 +253,7 @@ for more detail on how AutoDeploy is configured via the `**kwargs` of the `LLM` 
 ### Expert Configuration of LLM API
 
 For expert TensorRT-LLM users, we also expose the full set of [`LlmArgs`](../../tensorrt_llm/_torch/auto_deploy/llm_args.py#L201)
-*at your own risk*:
+*at your own risk* (the argument list diverges from TRT-LLM's argument list):
 
 <details>
 <summary>Click to expand for more details on using LlmArgs directly</summary>

--- a/tensorrt_llm/_torch/auto_deploy/llm_args.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm_args.py
@@ -3,11 +3,13 @@ from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
 import torch
-from pydantic import Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
 from ...llmapi.llm_args import BaseLlmArgs, BuildConfig, _ParallelConfig
 from ...llmapi.utils import get_type_repr
 from .models import ModelFactory, ModelFactoryRegistry
+
+PathLike = Union[str, Path]
 
 
 def _try_decode_dict_with_str_values(value: Dict[str, Any]) -> Dict[str, Any]:
@@ -21,15 +23,21 @@ def _try_decode_dict_with_str_values(value: Dict[str, Any]) -> Dict[str, Any]:
     return value
 
 
-class LlmArgs(BaseLlmArgs):
-    """LLM arguments specifically for AutoDeploy backend.
+class AutoDeployConfig(BaseModel):
+    """An argument class stripped down to AutoDeploy-specific configurations.
 
-    This class extends BaseLlmArgs with AutoDeploy-specific configuration options.
-    AutoDeploy provides automatic deployment and optimization of language models
-    with various attention backends and optimization strategies.
+    This class be used as a drop-in replacement to simplify configuring the AutoDeploy backend and
+    should be used in place of LlmArgs unless more advanced features are needed.
+
+    It is compatible with AutoDeploy's LLM API (``tensorrt_llm._torch.auto_deploy.llm.LLM``) and
+    exposes the full set of parameters used in AutoDeploy's ``InferenceOptimizer``.
     """
 
     ### MODEL AND TOKENIZER FACTORY ################################################################
+    model: PathLike = Field(
+        description="The path to the model checkpoint or the model name from the Hugging Face Hub."
+    )
+
     model_factory: Literal["AutoModelForCausalLM", "AutoModelForImageTextToText"] = Field(
         default="AutoModelForCausalLM",
         description="The model factory to use for loading the model.",
@@ -56,7 +64,7 @@ class LlmArgs(BaseLlmArgs):
         "Defaults to the same device as the rest of the pipeline.",
     )
 
-    tokenizer: Optional[Union[str, Path]] = Field(
+    tokenizer: Optional[PathLike] = Field(
         description="The tokenizer",
         default=None,
         repr=False,
@@ -68,6 +76,10 @@ class LlmArgs(BaseLlmArgs):
         "model_kwargs. For example, the default HF Llama tokenizer can be initialized with the "
         "arguments specified here: "
         "https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/tokenization_llama_fast.py#L127.",
+    )
+
+    skip_tokenizer_init: bool = Field(
+        default=False, description="Whether to skip the tokenizer initialization."
     )
 
     ### RUNTIME FEATURES ###########################################################################
@@ -139,6 +151,8 @@ class LlmArgs(BaseLlmArgs):
     visualize: bool = Field(default=False, description="Whether to visualize the model graph.")
 
     ### SEQUENCE INTERFACE CONFIG ##################################################################
+    max_input_len: int = Field(default=1024, description="The maximum input length.")
+    max_num_tokens: Optional[int] = Field(default=None, description="The maximum number of tokens.")
     max_seq_len: int = Field(default=512, ge=1, description="The maximum sequence length.")
     max_batch_size: int = Field(default=8, ge=1, description="The maximum batch size.")
     attn_page_size: int = Field(
@@ -149,7 +163,58 @@ class LlmArgs(BaseLlmArgs):
         "properly passed through.",
     )
 
-    ### !!! DO NOT USE !!! #########################################################################
+    ### VALIDATION #################################################################################
+    @field_validator("model_kwargs", "tokenizer_kwargs", mode="after")
+    @classmethod
+    def validate_model_kwargs(cls, value: Dict[str, Any]) -> Dict[str, Any]:
+        """Try to parse string values as JSON to convert to native types if possible."""
+        return _try_decode_dict_with_str_values(value)
+
+    @model_validator(mode="after")
+    def update_attn_page_size(self):
+        # NOTE force attn_page_size to equal max_seq_len for triton backend
+        if self.attn_backend == "triton":
+            self.attn_page_size = self.max_seq_len
+        return self
+
+    ### UTILITY METHODS ############################################################################
+    def create_factory(self) -> ModelFactory:
+        """Create a model factory from the arguments."""
+
+        return ModelFactoryRegistry.get(self.model_factory)(
+            model=self.model,
+            model_kwargs=self.model_kwargs,
+            tokenizer=self.tokenizer,
+            tokenizer_kwargs=self.tokenizer_kwargs,
+            skip_loading_weights=self.skip_loading_weights,
+            max_seq_len=self.max_seq_len,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the arguments to a dictionary."""
+        return self.model_dump()
+
+    def to_llm_args(self) -> "LlmArgs":
+        """Convert the arguments to a LlmArgs instance that is used for the LLM API."""
+        return LlmArgs(**self.to_dict())
+
+
+class LlmArgs(AutoDeployConfig, BaseLlmArgs):
+    """LlmArgs config class for providing full expert configurability of the AutoDeploy backend.
+
+    Specifically, this class extends AutoDeployArgs with all the fields from BaseLlmArgs for
+    providing configurability beyond what is provided by AutoDeployArgs.
+
+    Just like AutoDeployConfig, this class is compatible with AutoDeploy's LLM API
+    (``tensorrt_llm._torch.auto_deploy.llm.LLM``) but provides greater configurability.
+
+    NOTE: this class should only be used directly for advanced use cases. For most use cases,
+    AutoDeployConfig should be used instead.
+
+    NOTE: this class may expose redundant fields from BaseLlmArgs or fields that are ignored or
+    have overlapping functionality with AutoDeployArgs. Please be careful when using this class.
+    """
+
     build_config: Optional[object] = Field(
         default_factory=lambda: BuildConfig(),
         description="!!! DO NOT USE !!! Internal only; needed for BaseLlmArgs compatibility.",
@@ -174,15 +239,28 @@ class LlmArgs(BaseLlmArgs):
     @field_validator("build_config", mode="before")
     @classmethod
     def ensure_no_build_config(cls, value: Any) -> Any:
-        if value is not None:
-            raise ValueError("build_config is not used")
-        return value
+        raise ValueError("build_config is not in use by AutoDeploy's LlmArgs")
 
-    @field_validator("model_kwargs", "tokenizer_kwargs", mode="after")
+    @field_validator(
+        "tensor_parallel_size",
+        "pipeline_parallel_size",
+        "context_parallel_size",
+        "moe_cluster_parallel_size",
+        "moe_tensor_parallel_size",
+        "moe_expert_parallel_size",
+        "enable_attention_dp",
+        "cp_config",
+        mode="before",
+    )
     @classmethod
-    def validate_model_kwargs(cls, value: Dict[str, Any]) -> Dict[str, Any]:
-        """Try to parse string values as JSON to convert to native types if possible."""
-        return _try_decode_dict_with_str_values(value)
+    def ensure_no_custom_parallel_config(cls, value: Any, info: ValidationInfo) -> Any:
+        field_name = info.field_name
+        assert field_name is not None, "field_name should be set for validated field."
+        if value != cls.model_fields[field_name].get_default(call_default_factory=True):
+            raise ValueError(
+                "AutoDeply only supports parallelization via the `world_size` argument."
+            )
+        return value
 
     @model_validator(mode="after")
     def validate_parallel_config(self):
@@ -192,7 +270,6 @@ class LlmArgs(BaseLlmArgs):
         rank to automatically shard the model. This is just to ensure that other objects in the
         runtime that may read parallel_config can do so.
         """
-        # setup parallel config
         self._parallel_config = _ParallelConfig(
             auto_parallel=True, gpus_per_node=self.gpus_per_node
         )
@@ -204,26 +281,7 @@ class LlmArgs(BaseLlmArgs):
         """Skip tokenizer initialization in config. We do this in the AutoDeploy LLM class."""
         return self
 
-    @model_validator(mode="after")
-    def update_attn_page_size(self):
-        # NOTE force attn_page_size to equal max_seq_len for triton backend
-        if self.attn_backend == "triton":
-            self.attn_page_size = self.max_seq_len
-        return self
-
     ### UTILITY METHODS ############################################################################
-    def create_factory(self) -> ModelFactory:
-        """Create a model factory from the arguments."""
-
-        return ModelFactoryRegistry.get(self.model_factory)(
-            model=self.model,
-            model_kwargs=self.model_kwargs,
-            tokenizer=self.tokenizer,
-            tokenizer_kwargs=self.tokenizer_kwargs,
-            skip_loading_weights=self.skip_loading_weights,
-            max_seq_len=self.max_seq_len,
-        )
-
     # TODO: Remove this after the PyTorch backend is fully migrated to LlmArgs from ExecutorConfig
     def get_pytorch_backend_config(self) -> "LlmArgs":
         """Return the LlmArgs (self) object."""

--- a/tensorrt_llm/_torch/auto_deploy/llm_args.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm_args.py
@@ -202,8 +202,8 @@ class AutoDeployConfig(BaseModel):
 class LlmArgs(AutoDeployConfig, BaseLlmArgs):
     """LlmArgs config class for providing full expert configurability of the AutoDeploy backend.
 
-    Specifically, this class extends AutoDeployArgs with all the fields from BaseLlmArgs for
-    providing configurability beyond what is provided by AutoDeployArgs.
+    Specifically, this class extends AutoDeployConfig with all the fields from BaseLlmArgs for
+    providing configurability beyond what is provided by AutoDeployConfig.
 
     Just like AutoDeployConfig, this class is compatible with AutoDeploy's LLM API
     (``tensorrt_llm._torch.auto_deploy.llm.LLM``) but provides greater configurability.
@@ -212,7 +212,7 @@ class LlmArgs(AutoDeployConfig, BaseLlmArgs):
     AutoDeployConfig should be used instead.
 
     NOTE: this class may expose redundant fields from BaseLlmArgs or fields that are ignored or
-    have overlapping functionality with AutoDeployArgs. Please be careful when using this class.
+    have overlapping functionality with AutoDeployConfig. Please be careful when using this class.
     """
 
     build_config: Optional[object] = Field(
@@ -258,7 +258,7 @@ class LlmArgs(AutoDeployConfig, BaseLlmArgs):
         assert field_name is not None, "field_name should be set for validated field."
         if value != cls.model_fields[field_name].get_default(call_default_factory=True):
             raise ValueError(
-                "AutoDeply only supports parallelization via the `world_size` argument."
+                "AutoDeploy only supports parallelization via the `world_size` argument."
             )
         return value
 

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -25,7 +25,7 @@ from ...pyexecutor.scheduler import (
 )
 from ..custom_ops.attention_interface import SequenceInfo
 from ..distributed import common as dist
-from ..llm_args import LlmArgs
+from ..llm_args import AutoDeployConfig, LlmArgs
 from ..transformations.transform import InferenceOptimizer
 from ..utils.logger import ad_logger
 from .interface import CachedSequenceInterface, GetInferenceModel
@@ -82,8 +82,8 @@ class ADEngine(ModelEngine):
         return self.cache_seq_interface.device
 
     @classmethod
-    def build_from_config(cls, ad_config: LlmArgs):
-        """Build the ADEngine using the AD LlmArgs that gets passed through from the LLM."""
+    def build_from_config(cls, ad_config: AutoDeployConfig):
+        """Build the ADEngine using the AutoDeployConfig that gets passed through from the LLM."""
 
         max_batch_size = ad_config.max_batch_size
         max_seq_len = ad_config.max_seq_len

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -3,12 +3,12 @@
 import gc
 
 import torch
-from torch.fx import GraphModule
+import torch.nn as nn
 
 from ..compile import compile_and_capture
 from ..custom_ops.attention_interface import AttentionRegistry
 from ..distributed import common as dist_ad
-from ..llm_args import LlmArgs
+from ..llm_args import AutoDeployConfig
 from ..models.factory import ModelFactory
 from ..shim.interface import CachedSequenceInterface
 from ..utils.logger import ad_logger
@@ -38,11 +38,11 @@ from .library import (
 
 
 class InferenceOptimizer:
-    def __init__(self, factory: ModelFactory, ad_config: LlmArgs):
+    def __init__(self, factory: ModelFactory, ad_config: AutoDeployConfig):
         self.factory = factory
         self.ad_config = ad_config
 
-    def __call__(self, cm: CachedSequenceInterface) -> GraphModule:
+    def __call__(self, cm: CachedSequenceInterface) -> nn.Module:
         """Transform a model into an optimized inference model.
 
         Args:
@@ -54,7 +54,7 @@ class InferenceOptimizer:
             quantization: The quantization method to use. Defaults to None.
 
         Returns:
-            A GraphModule representing the optimized inference model.
+            A nn.Module representing the optimized inference model.
         """
         ############################################################################################
         # INITIALIZE MODEL

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_llm_config.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_llm_config.py
@@ -155,6 +155,32 @@ def test_invalid_model_factory():
 
 
 @pytest.mark.parametrize(
+    "parallel_field,invalid_value",
+    [
+        ("tensor_parallel_size", 2),
+        ("pipeline_parallel_size", 2),
+        ("context_parallel_size", 2),
+        ("moe_cluster_parallel_size", 2),
+        ("moe_tensor_parallel_size", 2),
+        ("moe_expert_parallel_size", 2),
+        ("enable_attention_dp", True),
+        ("cp_config", {"some_key": "some_value"}),
+    ],
+)
+def test_parallel_config_validation(parallel_field, invalid_value):
+    """Test that parallel config fields raise ValueError when set to non-default values."""
+    kwargs = {
+        "model": "test-model",
+        parallel_field: invalid_value,
+    }
+
+    with pytest.raises(
+        ValueError, match="AutoDeply only supports parallelization via the `world_size` argument."
+    ):
+        LlmArgs(**kwargs)
+
+
+@pytest.mark.parametrize(
     "attn_backend,expected_attn_page_size",
     [
         ("flashinfer", 64),  # Default attn_page_size

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_llm_config.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_llm_config.py
@@ -175,7 +175,7 @@ def test_parallel_config_validation(parallel_field, invalid_value):
     }
 
     with pytest.raises(
-        ValueError, match="AutoDeply only supports parallelization via the `world_size` argument."
+        ValueError, match="AutoDeploy only supports parallelization via the `world_size` argument."
     ):
         LlmArgs(**kwargs)
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -6,35 +6,35 @@ import pytest
 from _model_test_utils import get_small_model_config
 from build_and_run_ad import ExperimentConfig, main
 
-from tensorrt_llm._torch.auto_deploy.llm_args import LlmArgs, _ParallelConfig
+from tensorrt_llm._torch.auto_deploy.llm_args import AutoDeployConfig, LlmArgs, _ParallelConfig
 from tensorrt_llm._torch.auto_deploy.transformations.transform import InferenceOptimizer
 
 
-def _check_ad_config(experiment_config: ExperimentConfig, ad_config: LlmArgs):
+def _check_ad_config(experiment_config: ExperimentConfig, llm_args: LlmArgs):
     # Verify that ad_config was captured
-    assert ad_config is not None, "ad_config should have been captured"
+    assert llm_args is not None, "ad_config should have been captured"
 
-    # Check that ad_config is an instance of LlmArgs
-    assert isinstance(ad_config, LlmArgs), f"Expected AutoDeploy LlmArgs, got {type(ad_config)}"
+    # Check that ad_config is an instance of AutoDeployConfig
+    assert isinstance(llm_args, LlmArgs), f"Expected AutoDeploy LlmArgs, got {type(llm_args)}"
 
     # check that ad_config and experiment_config have the same args
-    assert experiment_config.args == ad_config, (
-        f"Expected experiment_config.args {experiment_config.args}, got {ad_config}"
-    )
+    expected_ad_config: AutoDeployConfig = experiment_config.args
+    expected_llm_args: LlmArgs = expected_ad_config.to_llm_args()
+    assert expected_llm_args == llm_args, f"Expected llm args {expected_llm_args}, got {llm_args}"
 
     # check expected parallel config
-    world_size = experiment_config.args.world_size
+    world_size = expected_ad_config.world_size
     expected_parallel_config = _ParallelConfig(
-        auto_parallel=True, gpus_per_node=experiment_config.args.gpus_per_node
+        auto_parallel=True, gpus_per_node=expected_llm_args.gpus_per_node
     )
     expected_parallel_config.world_size = world_size
-    assert ad_config._parallel_config == expected_parallel_config, (
-        f"Expected parallel_config {expected_parallel_config}, got {ad_config._parallel_config}"
+    assert llm_args._parallel_config == expected_parallel_config, (
+        f"Expected parallel_config {expected_parallel_config}, got {llm_args._parallel_config}"
     )
 
     # backend should always be "_autodeploy"
-    assert ad_config.backend == "_autodeploy", (
-        f"Expected backend '_autodeploy', got {ad_config.backend}"
+    assert llm_args.backend == "_autodeploy", (
+        f"Expected backend '_autodeploy', got {llm_args.backend}"
     )
 
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -11,13 +11,16 @@ from tensorrt_llm._torch.auto_deploy.transformations.transform import InferenceO
 
 
 def _check_ad_config(experiment_config: ExperimentConfig, llm_args: LlmArgs):
-    # Verify that ad_config was captured
-    assert llm_args is not None, "ad_config should have been captured"
+    # Verify that llm_args was captured
+    assert llm_args is not None, "llm_args should have been captured"
 
-    # Check that ad_config is an instance of AutoDeployConfig
-    assert isinstance(llm_args, LlmArgs), f"Expected AutoDeploy LlmArgs, got {type(llm_args)}"
+    # Check that llm_args is an instance of LlmArgs and also an instance of AutoDeployConfig
+    assert isinstance(llm_args, LlmArgs), f"Expected LlmArgs, got {type(llm_args)}"
+    assert isinstance(llm_args, AutoDeployConfig), (
+        f"Expected AutoDeployConfig, got {type(llm_args)}"
+    )
 
-    # check that ad_config and experiment_config have the same args
+    # check that llm_args and experiment_config have the same args
     expected_ad_config: AutoDeployConfig = experiment_config.args
     expected_llm_args: LlmArgs = expected_ad_config.to_llm_args()
     assert expected_llm_args == llm_args, f"Expected llm args {expected_llm_args}, got {llm_args}"


### PR DESCRIPTION
This PR refines AD configurability in the following ways

- [x] separate out core configs for AD (used in `InferenceOptimizer` and other core AD classes) into a separate config class
- [x] use multi inheritance to create `LlmArgs` class for AD to still provide optional full configurability for expert users if needed
- [x] Document use cases for both classes and added improved field validators for some overlapping fields like parallel config
- [x] Limit `build_and_run_ad.py` CLI to `AutoDeployConfig` instead of full `LlmArgs`


New CLI options with reduced configurability:

```bash
✗ python build_and_run_ad.py --help                                      

usage: build_and_run_ad.py [-h] [--args [JSON]] [--args.model {str,Path}] [--args.model-factory {AutoModelForCausalLM,AutoModelForImageTextToText}] [--args.model-kwargs Dict[str,Any]] [--args.skip-loading-weights bool]
                           [--args.checkpoint-device {str,null}] [--args.tokenizer {str,Path,null}] [--args.tokenizer-kwargs Dict[str,Any]] [--args.skip-tokenizer-init bool] [--args.disable-overlap-scheduler bool]
                           [--args.mixed-sampler bool] [--args.world-size int] [--args.runtime {demollm,trtllm}] [--args.device str] [--args.kv-cache-dtype str] [--args.attn-backend {flashinfer,triton}]
                           [--args.mla-backend MultiHeadLatentAttention] [--args.free-mem-ratio float] [--args.simple-shard-only bool] [--args.compile-backend {torch-simple,torch-compile,torch-cudagraph,torch-opt}]
                           [--args.cuda-graph-batch-sizes {List[int],null}] [--args.visualize bool] [--args.max-input-len int] [--args.max-num-tokens {int,null}] [--args.max-seq-len int] [--args.max-batch-size int]
                           [--args.attn-page-size int] [--model {str,null}] [--prompt [JSON]] [--prompt.batch-size int] [--prompt.queries {str,List[str]}] [--prompt.sp-kwargs Dict[str,Any]] [--benchmark [JSON]]
                           [--benchmark.enabled bool] [--benchmark.num int] [--benchmark.isl int] [--benchmark.osl int] [--benchmark.bs int] [--benchmark.results-path {str,null}] [--benchmark.store-results bool]
                           [--dry-run | --no-dry-run]

Experiment Configuration for the example script.

    This configuration aggregates all relevant configurations for this example script. It is also
    used to auto-generate the CLI interface.

options:
   [...]
```