### PR TITLE
[TRTLLM-5446 Part2] Add a torch no cache backend

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/llm_args.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm_args.py
@@ -115,7 +115,7 @@ class AutoDeployConfig(BaseModel):
     )
 
     # INFERENCE OPTIMIZER CONFIG ###################################################################
-    attn_backend: Literal["flashinfer", "triton"] = Field(
+    attn_backend: Literal["flashinfer", "triton", "torch-no-cache"] = Field(
         default="flashinfer", description="Attention backend to use."
     )
 

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -111,7 +111,7 @@ class ADEngine(ModelEngine):
         )
 
         # construct engine
-        return cls(build_and_optimize, seq_info, device)
+        return cls(build_and_optimize, seq_info, device, ad_config)
 
     @torch.inference_mode()
     def __init__(
@@ -119,6 +119,7 @@ class ADEngine(ModelEngine):
         get_inference_model: GetInferenceModel,
         seq_info: SequenceInfo,
         device: DeviceLikeType,
+        ad_config: AutoDeployConfig,
     ) -> None:
         """Initialize the engine with model and sequence information."""
         # NOTE (lucaslie): create a fake Namespace to satisfy PyExecutor requirements...
@@ -132,6 +133,9 @@ class ADEngine(ModelEngine):
 
         # NOTE (lucaslie): not a declared base member in the base class; required by PyExecutor...
         self.enable_attention_dp = False
+
+        # Store the ad_config for later access
+        self.use_cache = ad_config.attn_backend != "torch-no-cache"
 
         # construct cache sequence interface
         self.cache_seq_interface = CachedSequenceInterface(


### PR DESCRIPTION
## Description

This PR enables the flow to enable the torch attention reference operator without any caches. 

Changes includes
1. add a new torch-no-cache backend and register this as a backend. 
2. update the demollm to concat the input token to feed to the network instead of a single input token since the cache is not supported. 
3. misc update in the code. 

## Test Coverage

N/A