### PR TITLE
[None] Fix the torch interface

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
@@ -115,6 +115,9 @@ def bsnd_grouped_sdpa(
     dropout_p: float = 0.0,
     is_causal: bool = False,
     scale: Optional[float] = None,
+    sinks: Optional[torch.Tensor] = None,
+    sliding_window: Optional[int] = None,
+    logit_cap: Optional[float] = None,
 ) -> torch.Tensor:
     """Attention that assumes the input layout is bsnd.
 
@@ -134,7 +137,16 @@ def bsnd_grouped_sdpa(
 
 @bsnd_grouped_sdpa.register_fake
 def bsnd_grouped_sdpa_fake(
-    query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None
+    query,
+    key,
+    value,
+    attn_mask=None,
+    dropout_p=0.0,
+    is_causal=False,
+    scale=None,
+    sinks=None,
+    sliding_window=None,
+    logit_cap=None,
 ):
     """Fake implementation of bnsd grouped SDPA."""
     return query.new_empty(*query.shape[:-1], value.shape[-1]).contiguous()

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -75,7 +75,7 @@ def _check_ad_config(experiment_config: ExperimentConfig, llm_args: LlmArgs):
             compile_backend="torch-simple",
         ),
         get_small_model_config(
-            "meta-llama/Meta-Llama-3.1-8B-Instruct",
+            "microsoft/Phi-3-mini-4k-instruct",
             attn_backend="torch",
             compile_backend="torch-simple",
         ),


### PR DESCRIPTION
## Description

Fix the test failures in FAILED tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py::test_build_ad[experiment_config6] - RuntimeError: Could not find a value for 'sinks' on op auto_deploy.torch_attention_bsnd_grouped_sdpa by updating the torch reference interface. 