### PR TITLE
Attention Pattern Matcher (closes #4404)

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
@@ -96,23 +96,24 @@ def named_graphmodules(gm: fx.GraphModule) -> Iterator[Tuple[str, fx.GraphModule
             yield name, m
 
 
-def _move_single_gm_to_device(
-    gm: GraphModule, device: torch.device, recompile_graph: bool = False
-) -> None:
+def _move_single_gm_to_device(gm: GraphModule, device: torch.device) -> None:
     """Move one GraphModule and its nodes to the specified device in-place.
     Partially inspired by https://github.com/pytorch/pytorch/blob/05cb98f91d49df9eadfcb3fc29bbd1b621d88860/torch/export/passes/__init__.py#L11
     """
     # move state dict
     gm.to(device)
+    recompile_graph = False
 
     for node in gm.graph.nodes:
         # move all the nodes kwargs with burnt-in device
         if "device" in node.kwargs:
+            recompile_graph = True
             kwargs = node.kwargs.copy()
             kwargs["device"] = device
             node.kwargs = kwargs
 
         if is_op(node, torch.ops.aten.to.device):
+            recompile_graph = True
             args = list(node.args)
             args[1] = device
             node.args = tuple(args)
@@ -135,7 +136,7 @@ def move_to_device(gm: fx.GraphModule, device: DeviceLikeType) -> fx.GraphModule
 
     for _, subgm in reversed(list(named_graphmodules(gm))):
         # recompile graph to update self generated codes in subgraph
-        _move_single_gm_to_device(subgm, device, subgm is not gm)
+        _move_single_gm_to_device(subgm, device)
 
 
 def _is_impure_node(node: Node) -> bool:

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
@@ -1,10 +1,11 @@
 """Pattern matching for detecting repeat_kv pattern from Huggingface models."""
 
-from typing import Any, Dict, List, Type
+from contextlib import nullcontext
+from typing import Any, Callable, Dict, List, Type
 
 import torch
 import torch.nn.functional as F
-from torch.fx import GraphModule, Node
+from torch.fx import GraphModule
 
 from ...custom_ops.attention_interface import AttentionDescriptor
 from ...utils.logger import ad_logger
@@ -13,7 +14,76 @@ from ...utils.pattern_matcher import ADPatternMatcherPass, register_ad_pattern
 from .._graph import canonicalize_graph, lift_to_meta
 
 
-def _repeat_kv_pattern1(hidden_states, n_rep) -> torch.Tensor:
+def _apply_pattern(
+    gm: GraphModule,
+    pattern_name: str,
+    register_fn: Callable[[ADPatternMatcherPass], None],
+    shape_prop: bool = False,
+) -> None:
+    """Utility to register and apply a pattern."""
+    patterns = ADPatternMatcherPass()
+    register_fn(patterns)
+    num_matches = patterns.apply(gm.graph)
+
+    if num_matches > 0:
+        with lift_to_meta(gm) if shape_prop else nullcontext():
+            canonicalize_graph(gm, shape_prop=shape_prop)
+    ad_logger.info(f"Found and matched {num_matches} {pattern_name} pattern(s)")
+
+
+def match_attention_pattern(gm: GraphModule) -> None:
+    """Match and replace the attention pattern in the graph. Applying these transformations in sequence:
+
+    Match repeat_kv pattern and replace with torch.ops.auto_deploy.torch_attention_repeat_kv.
+    Match eager attention pattern and replace with torch.ops.auto_deploy.torch_attention_sdpa.
+    Match grouped attention pattern and replace with torch.ops.auto_deploy.torch_attention_grouped_sdpa
+    """
+
+    def register_repeat_kv(patterns: ADPatternMatcherPass):
+        dummy_args = [
+            torch.randn(8, 8, 16, 64, device="cuda", dtype=torch.float16),
+            7,
+        ]
+        register_ad_pattern(
+            search_fn=_repeat_kv_pattern,
+            replace_fn=_repeat_kv_repl,
+            patterns=patterns,
+            dummy_args=dummy_args,
+            op_ignore_types={
+                torch.ops.aten.reshape.default: (int,),
+                torch.ops.aten.expand.default: (int,),
+            },
+            scalar_workaround={"n_rep": dummy_args[1]},
+        )
+
+    def register_eager_attention(patterns: ADPatternMatcherPass):
+        for pattern_config in _get_sfdp_patterns():
+            register_ad_pattern(**pattern_config, patterns=patterns)
+
+    def register_grouped_attention(patterns: ADPatternMatcherPass):
+        dummy_args = [
+            torch.randn(8, 8, 16, 64, device="cuda", dtype=torch.float16),  # q
+            torch.randn(8, 1, 16, 64, device="cuda", dtype=torch.float16),  # k
+            torch.randn(8, 1, 16, 64, device="cuda", dtype=torch.float16),  # v
+            7,  # n_rep
+            torch.randn(8, 1, 1, 16, device="cuda", dtype=torch.float16),  # attn_mask
+            0.12345,  # dropout
+            0.56789,  # scale
+        ]
+        register_ad_pattern(
+            search_fn=_grouped_attn_pattern,
+            replace_fn=_grouped_attn_replacement,
+            patterns=patterns,
+            dummy_args=dummy_args,
+            scalar_workaround={"scale": 0.56789, "dropout_p": 0.12345, "n_rep": 7},
+        )
+
+    _apply_pattern(gm, "Repeat KV", register_repeat_kv, shape_prop=True)
+    _apply_pattern(gm, "Eager Attention", register_eager_attention)
+    _apply_pattern(gm, "Grouped Attention", register_grouped_attention)
+
+
+def _repeat_kv_pattern(hidden_states, n_rep) -> torch.Tensor:
     batch, num_key_value_heads, slen, head_dim = hidden_states.shape
     if n_rep == 1:
         return hidden_states
@@ -23,56 +93,8 @@ def _repeat_kv_pattern1(hidden_states, n_rep) -> torch.Tensor:
     return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
-def _repeat_kv_pattern2(hidden_states, n_rep) -> torch.Tensor:
-    # using the aten op directly will force the contiguous call to be inserted
-    return torch.ops.aten.contiguous.default(_repeat_kv_pattern1(hidden_states, n_rep))
-
-
 def _repeat_kv_repl(hidden_states, n_rep) -> torch.Tensor:
     return torch.ops.auto_deploy.torch_attention_repeat_kv(hidden_states, n_rep)
-
-
-def match_repeat_kv(gm: GraphModule) -> None:
-    """Match and replace the repeat_kv pattern in the graph.
-
-    This is replaced with torch.ops.auto_deploy.torch_attention_repeat_kv.
-    """
-    graph = gm.graph
-    patterns = ADPatternMatcherPass()
-
-    # dummy shapes: can be arbitrary
-    batch_size = 8
-    seq_len = 16
-    num_heads = 8
-    hidden_size = 512
-    head_dim = hidden_size // num_heads
-
-    dummy_explicit = [
-        torch.randn(batch_size, num_heads, seq_len, head_dim, device="meta", dtype=torch.float16),
-        7,
-    ]
-
-    def _register(search_fn):
-        register_ad_pattern(
-            search_fn=search_fn,
-            replace_fn=_repeat_kv_repl,
-            patterns=patterns,
-            dummy_args=dummy_explicit,
-            op_ignore_types={
-                torch.ops.aten.reshape.default: (int,),
-                torch.ops.aten.expand.default: (int,),
-            },
-            scalar_workaround={"n_rep": dummy_explicit[1]},
-        )
-
-    _register(_repeat_kv_pattern1)
-    # _register(_repeat_kv_pattern2)
-
-    num_matches = patterns.apply(graph)
-    # We do shape propagation here since dynamic shape information is lost during pattern matching
-    with lift_to_meta(gm):
-        canonicalize_graph(gm, shape_prop=True)
-    ad_logger.info(f"Found and matched {num_matches} Repeat KV patterns")
 
 
 # with causal_mask, no division
@@ -163,7 +185,7 @@ def _sfdp_replacement_4(query, key, value, scaling, dropout):
     )
 
 
-# no causal_mask, with division, 'complex' model
+# no causal_mask, with division, explicit casting model
 def _sfdp_pattern_5(query, key, value, scaling, dropout):
     attn_weights = torch.matmul(query, key.transpose(2, 3)) / scaling
     attn_weights = attn_weights.to(torch.float32)
@@ -186,7 +208,7 @@ def _sfdp_replacement_5(query, key, value, scaling, dropout):
     )
 
 
-# with causal_mask, with division, 'complex' model
+# with causal_mask, with division, explicit casting model
 def _sfdp_pattern_6(query, key, value, attention_mask, scaling, dropout):
     attn_weights = torch.matmul(query, key.transpose(2, 3)) / scaling
     attn_weights = attn_weights + attention_mask
@@ -211,135 +233,42 @@ def _sfdp_replacement_6(query, key, value, attention_mask, scaling, dropout):
 
 
 def _get_sfdp_patterns() -> List[Dict[str, Any]]:
-    bs = 8
-    seq_len = 16
-    n_heads = 8
-    hidden_size = 512
+    bs, seq_len, n_heads, hidden_size = 8, 16, 8, 512
     head_dim = hidden_size // n_heads
-    return [
-        {
-            "search_fn": _sfdp_pattern_1,
-            "replace_fn": _sfdp_replacement_1,
-            "dummy_args": [
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                torch.randn(bs, 1, 1, seq_len, device="cuda", dtype=torch.bfloat16),
-                0.1234743,  # scaling
-                0.85849734,  # dropout
-            ],
-            "scalar_workaround": {"dropout": 0.85849734, "scaling": 0.1234743},
-            "op_ignore_types": {
-                torch.ops.aten.to.dtype: (torch.dtype,),
-            },
-        },
-        {
-            "search_fn": _sfdp_pattern_2,
-            "replace_fn": _sfdp_replacement_2,
-            "dummy_args": [
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                0.234743,  # scaling
-                0.5849734,  # dropout
-            ],
-            "scalar_workaround": {"dropout": 0.5849734, "scaling": 0.234743},
-            "op_ignore_types": {
-                torch.ops.aten.to.dtype: (torch.dtype,),
-            },
-        },
-        {
-            "search_fn": _sfdp_pattern_3,
-            "replace_fn": _sfdp_replacement_3,
-            "dummy_args": [
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                torch.randn(bs, 1, 1, seq_len, device="cuda", dtype=torch.bfloat16),
-                0.34743,  # scaling
-                0.849734,  # dropout
-            ],
-            "scalar_workaround": {
-                "scaling": 0.34743,
-                "dropout": 0.849734,
-            },
-            "op_ignore_types": {
-                torch.ops.aten.to.dtype: (torch.dtype,),
-            },
-        },
-        {
-            "search_fn": _sfdp_pattern_4,
-            "replace_fn": _sfdp_replacement_4,
-            "dummy_args": [
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                0.74321,  # scaling
-                0.9734,  # dropout
-            ],
-            "scalar_workaround": {
-                "scaling": 0.74321,
-                "dropout": 0.9734,
-            },
-            "op_ignore_types": {
-                torch.ops.aten.to.dtype: (torch.dtype,),
-            },
-        },
-        {
-            "search_fn": _sfdp_pattern_5,
-            "replace_fn": _sfdp_replacement_5,
-            "dummy_args": [
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                0.874321,  # scaling
-                0.89734,  # dropout
-            ],
-            "scalar_workaround": {
-                "scaling": 0.874321,
-                "dropout": 0.89734,
-            },
-            "op_ignore_types": {
-                torch.ops.aten.to.dtype: (torch.dtype,),
-            },
-        },
-        {
-            "search_fn": _sfdp_pattern_6,
-            "replace_fn": _sfdp_replacement_6,
-            "dummy_args": [
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16),
-                torch.randn(bs, 1, 1, seq_len, device="cuda", dtype=torch.bfloat16),
-                0.634743,  # scaling
-                0.6849734,  # dropout
-            ],
-            "scalar_workaround": {
-                "scaling": 0.634743,
-                "dropout": 0.6849734,
-            },
-            "op_ignore_types": {
-                torch.ops.aten.to.dtype: (torch.dtype,),
-            },
-        },
+
+    def common_tensor():
+        return torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16)
+
+    def causal_mask():
+        return torch.randn(bs, 1, 1, seq_len, device="cuda", dtype=torch.bfloat16)
+
+    configs = [
+        (_sfdp_pattern_1, _sfdp_replacement_1, True, 0.1234743, 0.85849734),
+        (_sfdp_pattern_2, _sfdp_replacement_2, False, 0.234743, 0.5849734),
+        (_sfdp_pattern_3, _sfdp_replacement_3, True, 0.34743, 0.849734),
+        (_sfdp_pattern_4, _sfdp_replacement_4, False, 0.74321, 0.9734),
+        (_sfdp_pattern_5, _sfdp_replacement_5, False, 0.874321, 0.89734),
+        (_sfdp_pattern_6, _sfdp_replacement_6, True, 0.634743, 0.6849734),
     ]
 
+    patterns = []
+    for search_fn, replace_fn, has_mask, scale, dropout in configs:
+        dummy_args = [common_tensor(), common_tensor(), common_tensor()]
+        if has_mask:
+            dummy_args.append(causal_mask())
+        dummy_args.extend([scale, dropout])
 
-def match_eager_attention(gm: GraphModule) -> None:
-    """Match and replace the eager attention pattern in fx graphs.
+        patterns.append(
+            {
+                "search_fn": search_fn,
+                "replace_fn": replace_fn,
+                "dummy_args": dummy_args,
+                "scalar_workaround": {"scaling": scale, "dropout": dropout},
+                "op_ignore_types": {torch.ops.aten.to.dtype: (torch.dtype,)},
+            }
+        )
 
-    This is replaced with torch.ops.auto_deploy.torch_attention_sdpa.
-    """
-    graph = gm.graph
-    patterns = ADPatternMatcherPass()
-
-    for pattern_config in _get_sfdp_patterns():
-        register_ad_pattern(**pattern_config, patterns=patterns)
-
-    # Apply patterns and clean-up
-    num_matches = patterns.apply(graph)
-    canonicalize_graph(gm)
-    ad_logger.info(f"Found and matched {num_matches} Eager Attention patterns")
+    return patterns
 
 
 def _grouped_attn_pattern(q, k, v, n_rep, attn_mask, dropout_p, scale):
@@ -354,308 +283,6 @@ def _grouped_attn_replacement(q, k, v, n_rep, attn_mask, dropout_p, scale):
     return torch.ops.auto_deploy.torch_attention_grouped_sdpa.default(
         q, k, v, attn_mask=attn_mask, dropout_p=dropout_p, is_causal=False, scale=scale
     )
-
-
-def match_grouped_attention(gm: GraphModule) -> None:
-    """Match and replace the grouped attention pattern using pattern matcher util."""
-    graph = gm.graph
-    patterns = ADPatternMatcherPass()
-
-    # Dummy inputs: meta tensors for FX tracing
-    bs, seqlen, n_heads, hidden_size = 8, 16, 8, 512
-    head_dim = hidden_size // n_heads
-
-    dummy_args = [
-        torch.randn(bs, n_heads, seqlen, head_dim, device="meta", dtype=torch.float16),  # q
-        torch.randn(bs, 1, seqlen, head_dim, device="meta", dtype=torch.float16),  # k
-        torch.randn(bs, 1, seqlen, head_dim, device="meta", dtype=torch.float16),  # v
-        7,  # n_rep
-        torch.randn(bs, 1, 1, seqlen, device="meta", dtype=torch.float16),  # attn_mask
-        0.12345,  # dropout
-        0.56789,  # scale
-    ]
-
-    scalar_workaround = {"scale": 0.56789, "dropout_p": 0.12345, "n_rep": 7}
-
-    register_ad_pattern(
-        search_fn=_grouped_attn_pattern,
-        replace_fn=_grouped_attn_replacement,
-        patterns=patterns,
-        dummy_args=dummy_args,
-        op_ignore_types={},
-        scalar_workaround=scalar_workaround,
-    )
-
-    num_matches = patterns.apply(graph)
-    canonicalize_graph(gm)
-    ad_logger.info(f"Found and matched {num_matches} Grouped Attention patterns")
-
-
-def match_causal_attn_mask(gm: GraphModule) -> None:
-    """
-    Match attention operations with causal attention masks and optimize them.
-
-    For operations that use explicit causal masks, this replaces:
-    - sdpa(q, k, v, causal_mask, dropout_p, False, scale)
-    with:
-    - sdpa(q, k, v, None, dropout_p, True, scale)
-
-    This optimization enables more efficient implementations on supported backends.
-    """
-    graph = gm.graph
-
-    # Track replacements to avoid processing nodes multiple times
-    num_causal_patterns = 0
-
-    # Iterate through nodes in the graph
-    for node in list(graph.nodes):
-        # Look for SDPA nodes or grouped SDPA nodes
-        if not (
-            is_op(node, torch.ops.auto_deploy.torch_attention_sdpa)
-            or is_op(node, torch.ops.auto_deploy.torch_attention_grouped_sdpa)
-        ):
-            continue
-
-        # Get the attention mask argument (4th argument)
-        if len(node.args) < 4 or node.args[3] is None:
-            continue
-
-        attn_mask = node.args[3]
-
-        # Check if this mask is a causal mask
-        if not _is_causal_mask(attn_mask):
-            ad_logger.debug(f"Found non-causal attention mask at {node=}!")
-            continue
-
-        ad_logger.debug(f"Found causal attention mask at {node}")
-
-        # construct the new args list with args provided to the node and the default values otherwise
-        new_args = []
-        for idx, arg in enumerate(node.target._schema.arguments):
-            # In case arg is provided to the node, use it
-            if idx < len(node.args):
-                new_args.append(node.args[idx])
-            # In case arg is not provided to the node, use the default value
-            elif arg.has_default_value:
-                new_args.append(arg.default_value)
-            else:
-                raise ValueError(f"Missing required argument: {arg.name}")
-
-        # Create new arguments with None mask and is_causal=True
-        new_args[3] = None  # Set mask to None
-        new_args[5] = True  # Set is_causal to True
-
-        # Create new node with updated arguments
-        with graph.inserting_before(node):
-            new_node = graph.call_function(node.target, args=tuple(new_args), kwargs=node.kwargs)
-
-        # Preserve metadata
-        new_node.meta = node.meta.copy()
-
-        # Replace the old node with the new one
-        node.replace_all_uses_with(new_node)
-
-        num_causal_patterns += 1
-
-    # Clean up the graph if we made any replacements
-    if num_causal_patterns:
-        canonicalize_graph(gm)
-    ad_logger.info(f"Found {num_causal_patterns} causal mask attention patterns")
-
-
-def _is_causal_mask(mask_node: Node) -> bool:
-    """
-    Determine if a node represents a causal attention mask.
-
-    Causal masks typically involve:
-    1. Creating a matrix with very negative values (e.g., -inf or close to it)
-    2. Using triu with offset 1 to create an upper triangular matrix
-    3. Usually involves comparison operations (gt, lt) with position indices
-
-    Returns True if the node appears to be a causal mask pattern.
-    """
-    # Direct pattern from the test case: masked_fill with triu(ones,1) and -inf
-    if is_op(mask_node, torch.ops.aten.masked_fill):
-        mask_args = mask_node.args
-        if len(mask_args) >= 2:
-            _ = mask_args[0]  # zero tensor
-            mask_tensor = mask_args[1]
-            fill_value = mask_args[2] if len(mask_args) > 2 else mask_node.kwargs.get("value", None)
-
-            # Check if fill value is very negative (e.g., -inf)
-            if fill_value is not None and (
-                fill_value == float("-inf")
-                or (isinstance(fill_value, (int, float)) and fill_value < -1e4)
-            ):
-                # Try to trace back to find a triu pattern
-                if _has_triu_ancestor(mask_tensor, offset=1):
-                    return True
-
-    # Pattern from negative_fill test case: masked_fill with ~triu(ones,1) and 0.0
-    # The negative_fill pattern has a pre-filled tensor with very negative values
-    # and zeros in the lower triangle
-    if is_op(mask_node, torch.ops.aten.masked_fill):
-        mask_args = mask_node.args
-        if len(mask_args) >= 2:
-            negative_tensor = mask_args[0]
-            mask_tensor = mask_args[1]
-            fill_value = mask_args[2] if len(mask_args) > 2 else mask_node.kwargs.get("value", None)
-
-            # Check if fill value is zero and the tensor is pre-filled with negative values
-            if fill_value == 0.0 or fill_value == 0:
-                # Check for the full tensor with negative values
-                if is_op(negative_tensor, torch.ops.aten.full):
-                    fill_args = negative_tensor.args
-                    if (
-                        len(fill_args) > 1
-                        and isinstance(fill_args[1], (int, float))
-                        and fill_args[1] < -1e4
-                    ):
-                        # This is likely a negative-filled tensor
-                        # Now check if the mask is a bitwise_not of triu
-                        if is_op(mask_tensor, torch.ops.aten.bitwise_not):
-                            if len(mask_tensor.args) > 0 and _has_triu_ancestor(
-                                mask_tensor.args[0], offset=1
-                            ):
-                                return True
-
-    # Pattern for llama-3.1 style causal mask: slice of expand(unsqueeze(unsqueeze(mul_(triu, gt))))
-    if is_op(mask_node, torch.ops.aten.slice):
-        # Follow the chain backward to the source of the slice
-        if len(mask_node.args) == 0:
-            return False
-        slice_source = mask_node.args[0]
-
-        # Check for typical expand pattern
-        if not (slice_source and is_op(slice_source, torch.ops.aten.expand)):
-            return False
-
-        # Continue tracing back through the pattern
-        if len(slice_source.args) == 0:
-            return False
-        expand_source = slice_source.args[0]
-
-        # Check for first unsqueeze operation
-        if not (expand_source and is_op(expand_source, torch.ops.aten.unsqueeze)):
-            return False
-
-        # Look for the source of first unsqueeze
-        if len(expand_source.args) == 0:
-            return False
-        first_unsqueeze_source = expand_source.args[0]
-
-        # Check for second unsqueeze operation
-        if not (first_unsqueeze_source and is_op(first_unsqueeze_source, torch.ops.aten.unsqueeze)):
-            return False
-
-        # Look for the source of the second unsqueeze
-        if len(first_unsqueeze_source.args) == 0:
-            return False
-        second_unsqueeze_source = first_unsqueeze_source.args[0]
-
-        # Check for mul_ operation
-        if is_op(second_unsqueeze_source, torch.ops.aten.mul_):
-            # Check if one of the mul_ arguments is a triu operation
-            has_triu = False
-            for arg in second_unsqueeze_source.args:
-                if is_op(arg, torch.ops.aten.triu):
-                    if len(arg.args) > 1 and arg.args[1] == 1:
-                        has_triu = True
-                        break
-
-            if has_triu:
-                # Check if one of the mul_ arguments involves a full tensor with negative values
-                for arg in second_unsqueeze_source.args:
-                    if is_op(arg, torch.ops.aten.full):
-                        if (
-                            len(arg.args) > 1
-                            and isinstance(arg.args[1], (int, float))
-                            and arg.args[1] < -1e4
-                        ):
-                            return True
-
-            return has_triu
-
-    # Original implementation for backward compatibility
-    if is_op(mask_node, torch.ops.aten.slice):
-        # Follow the chain backward to the source of the slice
-        if len(mask_node.args) == 0:
-            return False
-        slice_source = mask_node.args[0]
-
-        # Check for typical expand pattern
-        if not (slice_source and is_op(slice_source, torch.ops.aten.expand)):
-            return False
-
-        # Continue tracing back through the pattern
-        if len(slice_source.args) == 0:
-            return False
-        expand_source = slice_source.args[0]
-
-        # Check for unsqueeze operations
-        if not (expand_source and is_op(expand_source, torch.ops.aten.unsqueeze)):
-            return False
-
-        # Look for the source of the unsqueeze
-        if len(expand_source.args) == 0:
-            return False
-        unsqueeze_source = expand_source.args[0]
-
-        if not unsqueeze_source:
-            return False
-
-        # Check for triu pattern which is common in causal masks
-        if is_op(unsqueeze_source, torch.ops.aten.mul_):
-            for arg in unsqueeze_source.args:
-                if not is_op(arg, torch.ops.aten.triu):
-                    continue
-
-                if len(arg.args) <= 1:
-                    continue
-
-                triu_offset = arg.args[1]
-                # Causal masks typically use triu with offset 1
-                if triu_offset == 1:
-                    return True
-
-            return False
-
-        # Check if we have a full tensor filled with a very negative number
-        if not is_op(unsqueeze_source, torch.ops.aten.full):
-            return False
-
-        if len(unsqueeze_source.args) <= 1:
-            return False
-
-        fill_value = unsqueeze_source.args[1]
-        # Check if the fill value is very negative (likely -inf or close)
-        if isinstance(fill_value, float) and fill_value < -1e10:
-            return True
-
-    # If we can't definitively identify it as causal, return False
-    return False
-
-
-def _has_triu_ancestor(node: Node, offset: int = 1, depth: int = 0, max_depth: int = 5) -> bool:
-    """Helper function to find a triu operation in the ancestry of a node."""
-    if depth > max_depth:  # Prevent infinite recursion
-        return False
-
-    if is_op(node, torch.ops.aten.triu):
-        if len(node.args) > 1 and node.args[1] == offset:
-            return True
-
-    # Check if any of the arguments has a triu ancestor
-    for arg in node.args:
-        if isinstance(arg, Node) and _has_triu_ancestor(arg, offset, depth + 1, max_depth):
-            return True
-
-    # Check if any of the kwargs has a triu ancestor
-    for value in node.kwargs.values():
-        if isinstance(value, Node) and _has_triu_ancestor(value, offset, depth + 1, max_depth):
-            return True
-
-    return False
 
 
 def match_attention_layout(gm: GraphModule, attention_op: Type[AttentionDescriptor]) -> None:

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
@@ -1,4 +1,4 @@
-"""Pattern matching for detecting repeat_kv pattern from Huggingface models."""
+"""Pattern matching for detecting eager and grouped attention pattern from Huggingface models."""
 
 from contextlib import nullcontext
 from typing import Any, Callable, Dict, List, Type

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
@@ -69,8 +69,9 @@ def match_repeat_kv(gm: GraphModule) -> None:
     # _register(_repeat_kv_pattern2)
 
     num_matches = patterns.apply(graph)
+    # We do shape propagation here since dynamic shape information is lost during pattern matching
     with lift_to_meta(gm):
-        gm = canonicalize_graph(gm, shape_prop=True)
+        canonicalize_graph(gm, shape_prop=True)
     ad_logger.info(f"Found and matched {num_matches} Repeat KV patterns")
 
 
@@ -337,7 +338,7 @@ def match_eager_attention(gm: GraphModule) -> None:
 
     # Apply patterns and clean-up
     num_matches = patterns.apply(graph)
-    gm = canonicalize_graph(gm)
+    canonicalize_graph(gm)
     ad_logger.info(f"Found and matched {num_matches} Eager Attention patterns")
 
 
@@ -386,7 +387,7 @@ def match_grouped_attention(gm: GraphModule) -> None:
     )
 
     num_matches = patterns.apply(graph)
-    gm = canonicalize_graph(gm)
+    canonicalize_graph(gm)
     ad_logger.info(f"Found and matched {num_matches} Grouped Attention patterns")
 
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
@@ -32,9 +32,11 @@ def _apply_pattern(
 
 
 def match_attention_pattern(gm: GraphModule) -> None:
-    """Match and replace the attention pattern in the graph. Applying these transformations in sequence:
-    Match eager attention pattern and replace with torch.ops.auto_deploy.torch_attention_sdpa.
-    Match grouped attention pattern and replace with torch.ops.auto_deploy.torch_attention_grouped_sdpa
+    """
+    Match and replace attention patterns in the graph.
+
+    This transformation detects both eager (ungrouped) and grouped attention patterns,
+    and replaces them with `torch.ops.auto_deploy.torch_attention_grouped_sdpa`.
     """
 
     def register_eager_attention(patterns: ADPatternMatcherPass):

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -25,11 +25,8 @@ from .library import (
     fuse_rmsnorm,
     insert_cached_attention,
     match_attention_layout,
-    match_causal_attn_mask,
-    match_eager_attention,
-    match_grouped_attention,
+    match_attention_pattern,
     match_moe_pattern,
-    match_repeat_kv,
     match_rope_layout,
     match_rope_pattern,
     optimize_rope,
@@ -78,17 +75,8 @@ class InferenceOptimizer:
         # Match MoE pattern
         match_moe_pattern(egm)
 
-        # Match repeat_kv pattern
-        match_repeat_kv(egm)
-
-        # Match eager attention pattern
-        match_eager_attention(egm)
-
-        # Match grouped attention pattern
-        match_grouped_attention(egm)
-
-        # Match and optimize causal attention masks
-        match_causal_attn_mask(egm)
+        # Match attention pattern
+        match_attention_pattern(egm)
 
         # Match attention layout expected by our backend
         match_attention_layout(egm, AttentionRegistry.get(self.ad_config.attn_backend))

--- a/tensorrt_llm/_torch/auto_deploy/utils/pattern_matcher.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/pattern_matcher.py
@@ -153,6 +153,8 @@ def register_ad_pattern(
     5. register_replacement can auto-generate `search_fn_pattern` if you input `example_inputs`,
         but that approach will fail when symbolic shapes are involved. Here
         we explicitly trace & convert via `fx_to_pattern`.
+    6. The PatternMatcherPass would check num_users of the nodes, meaning that the pattern is required
+        to be functionally isolated, no intermediate nodes are shared with the rest of the graph.
 
     """
     argnames = list(inspect.signature(search_fn).parameters.keys())

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher.py
@@ -141,7 +141,6 @@ class EagerAttentionModel(torch.nn.Module):
         self.out_proj = torch.nn.Linear(num_heads * self.head_dim, hidden_size)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        print("self.training: ", self.training)
         batch_size, seq_len, _ = x.shape
         device = x.device
         dtype = x.dtype

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
@@ -11,8 +11,8 @@ from torch.fx import GraphModule
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaModel
 
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transformations._graph import move_to_device
-from tensorrt_llm._torch.auto_deploy.transformations.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transformations.library import (
     match_attention_layout,
     match_attention_pattern,
@@ -85,6 +85,10 @@ def test_match_llama_attention(config: Dict[str, Any], attn_implementation: str)
             op="call_function", target=torch.ops.auto_deploy.torch_attention_repeat_kv
         )
         assert len(nodes) == 0, "Found repeat_kv pattern in the graph"
+        attn_nodes = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.auto_deploy.torch_attention_sdpa
+        )
+        assert len(attn_nodes) == 0, "Found torch_attention_sdpa node in the graph"
 
         return True
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
@@ -135,4 +135,4 @@ def test_match_llama_attention(config: Dict[str, Any], attn_implementation: str)
 
     # Verify output
     y_gm = gm(x)
-    torch.testing.assert_close(y_model, y_gm, atol=1e-3, rtol=5e-2)
+    torch.testing.assert_close(y_model, y_gm, atol=5e-3, rtol=5e-3)


### PR DESCRIPTION
## Description

Use torch._inductor pattern matcher to match attention

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
