### PR TITLE
[AutoDeploy] Modular export patches + registry; fixes #5728

### DIFF
--- a/examples/auto_deploy/build_and_run_flux.py
+++ b/examples/auto_deploy/build_and_run_flux.py
@@ -6,7 +6,7 @@ import torch
 from diffusers import DiffusionPipeline
 
 from tensorrt_llm._torch.auto_deploy.compile import compile_and_capture
-from tensorrt_llm._torch.auto_deploy.transformations.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transformations.library.fusion import fuse_gemms
 from tensorrt_llm._torch.auto_deploy.transformations.library.quantization import quantize
 from tensorrt_llm._torch.auto_deploy.utils.logger import ad_logger

--- a/tensorrt_llm/_torch/auto_deploy/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/__init__.py
@@ -1,5 +1,5 @@
 # import submodules that require registration process
-from . import compile, custom_ops, models, shim  # noqa: F401
+from . import compile, custom_ops, export, models, shim  # noqa: F401
 
 # import AutoDeploy LLM and LlmArgs
 from .llm import *

--- a/tensorrt_llm/_torch/auto_deploy/export/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/__init__.py
@@ -1,0 +1,5 @@
+"""AutoDeploy's modular export patch system."""
+
+from . import library  # ensure all patches are registered
+from .export import *
+from .interface import *

--- a/tensorrt_llm/_torch/auto_deploy/export/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/interface.py
@@ -1,0 +1,249 @@
+"""The interface for all export patches.
+
+This module defines the base classes and interfaces for all export patches.
+"""
+
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from typing import Any, Callable, Dict, Type, Union, final
+
+from pydantic import BaseModel, Field
+
+from ..utils.logger import ad_logger
+
+
+class ExportPatchError(Exception):
+    """An exception raised when an export patch fails."""
+
+    pass
+
+
+class ExportPatchConfig(BaseModel):
+    """Base configuration class for export patches."""
+
+    model_config = {
+        "extra": "allow",  # Allow subclasses to add more fields
+    }
+
+    enabled: bool = Field(
+        default=True,
+        description="Whether to enable this patch.",
+    )
+    skip_on_error: bool = Field(
+        default=False,
+        description="Whether to skip the patch if an error occurs during application.",
+    )
+
+
+class BaseExportPatch(ABC):
+    """Base class for all export patches.
+
+    Export patches are context managers that apply temporary modifications
+    to the global state during torch.export, then revert them afterwards.
+    """
+
+    config: ExportPatchConfig
+    _patch_key: str  # Set by ExportPatchRegistry.register() decorator
+
+    @classmethod
+    def get_patch_key(cls) -> str:
+        """Get the short name of the patch."""
+        if hasattr(cls, "_patch_key"):
+            return cls._patch_key
+        raise NotImplementedError(
+            f"Patch class {cls.__name__} must be registered with ExportPatchRegistry.register() "
+            "or manually implement get_patch_key()"
+        )
+
+    @classmethod
+    def get_config_class(cls) -> Type[ExportPatchConfig]:
+        """Get the configuration class for the patch."""
+        return ExportPatchConfig
+
+    @final
+    def __init__(self, config: ExportPatchConfig):
+        """Initialize the patch.
+
+        Args:
+            config: The configuration for the patch.
+        """
+        if not isinstance(config, self.get_config_class()):
+            config = self.get_config_class()(**config.model_dump())
+        self.config = config
+        self.original_values = {}
+        self._post_init()
+
+    def _post_init(self):
+        """Post-initialization hook that can be overridden by subclasses."""
+        pass
+
+    @final
+    @classmethod
+    def from_kwargs(cls, **kwargs) -> "BaseExportPatch":
+        """Create a patch from kwargs."""
+        config = cls.get_config_class()(**kwargs)
+        return cls(config=config)
+
+    @final
+    def __enter__(self):
+        """Enter the context manager and apply the patch."""
+        if not self.config.enabled:
+            ad_logger.debug(f"Patch {self.get_patch_key()} is disabled, skipping")
+            return self
+
+        try:
+            ad_logger.debug(f"Applying patch: {self.get_patch_key()}")
+            self._apply_patch()
+        except Exception as e:
+            error_msg = f"Patch {self.get_patch_key()} failed to apply"
+            if self.config.skip_on_error:
+                ad_logger.warning(f"{error_msg}: {e}")
+            else:
+                raise ExportPatchError(error_msg) from e
+
+        return self
+
+    @final
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exit the context manager and revert the patch."""
+        if not self.config.enabled:
+            return
+
+        try:
+            ad_logger.debug(f"Reverting patch: {self.get_patch_key()}")
+            self._revert_patch()
+        except Exception as e:
+            error_msg = f"Patch {self.get_patch_key()} failed to revert"
+            if self.config.skip_on_error:
+                ad_logger.warning(f"{error_msg}: {e}")
+            else:
+                raise ExportPatchError(error_msg) from e
+
+    @abstractmethod
+    def _apply_patch(self):
+        """Apply the patch. Should store original values in self.original_values."""
+        pass
+
+    @abstractmethod
+    def _revert_patch(self):
+        """Revert the patch using stored original values."""
+        pass
+
+
+class ContextManagerPatch(BaseExportPatch):
+    """A patch that wraps an existing context manager.
+
+    This allows easy registration of context managers as patches without
+    having to implement the full BaseExportPatch interface.
+
+    Subclasses must implement `init_context_manager()` to return the context manager.
+    """
+
+    def _post_init(self):
+        self.context_manager: Any = None
+
+    @abstractmethod
+    def init_context_manager(self) -> Any:
+        """Initialize and return the context manager.
+
+        Returns:
+            A context manager that will be used during export.
+        """
+        pass
+
+    def _apply_patch(self):
+        """Apply the patch by entering the context manager."""
+        self.context_manager = self.init_context_manager()
+        self.context_manager.__enter__()
+
+    def _revert_patch(self):
+        """Revert the patch by exiting the context manager."""
+        if self.context_manager is not None:
+            self.context_manager.__exit__(None, None, None)
+            self.context_manager = None
+
+
+class ExportPatchRegistry:
+    """Registry for export patches."""
+
+    _registry: Dict[str, Type[BaseExportPatch]] = {}
+
+    @classmethod
+    def register(cls, name: str) -> Callable[[Type[BaseExportPatch]], Type[BaseExportPatch]]:
+        """Register a patch class with the given name."""
+
+        def inner(patch_cls: Type[BaseExportPatch]) -> Type[BaseExportPatch]:
+            cls._registry[name] = patch_cls
+            # Auto-store the patch key as a class attribute
+            patch_cls._patch_key = name
+            return patch_cls
+
+        return inner
+
+    @classmethod
+    def get(cls, name: str) -> Type[BaseExportPatch]:
+        """Get a patch class by name."""
+        return cls._registry[name]
+
+    @classmethod
+    def get_config_class(cls, name: str) -> Type[ExportPatchConfig]:
+        """Get the configuration class for a patch by name."""
+        return cls.get(name).get_config_class()
+
+    @classmethod
+    def has(cls, name: str) -> bool:
+        """Check if a patch is registered."""
+        return name in cls._registry
+
+    @classmethod
+    def create_patch(
+        cls, name: str, config: Union[ExportPatchConfig, Dict[str, Any]]
+    ) -> BaseExportPatch:
+        """Create a patch instance by name."""
+        patch_cls = cls.get(name)
+        if isinstance(config, dict):
+            config = patch_cls.get_config_class()(**config)
+        return patch_cls(config)
+
+    @classmethod
+    def list_patches(cls) -> list[str]:
+        """List all registered patch names."""
+        return list(cls._registry.keys())
+
+
+@contextmanager
+def apply_export_patches(patch_configs: Dict[str, Union[ExportPatchConfig, Dict[str, Any]]]):
+    """Context manager to apply multiple patches.
+
+    Args:
+        patch_configs: Dict mapping patch names to their configurations.
+    """
+    patches = []
+
+    # Create patch instances
+    for name, config in patch_configs.items():
+        if not ExportPatchRegistry.has(name):
+            raise ValueError(f"Unknown patch: {name}")
+        patch = ExportPatchRegistry.create_patch(name, config)
+        patches.append(patch)
+
+    # Apply patches using nested context managers
+    if not patches:
+        yield
+        return
+
+    def _apply_patches(remaining_patches):
+        if not remaining_patches:
+            yield
+            return
+
+        patch = remaining_patches[0]
+        with patch:
+            yield from _apply_patches(remaining_patches[1:])
+
+    # log applied patches
+    ad_logger.info(
+        f"applying export patches: {', '.join([patch.get_patch_key() for patch in patches])}"
+    )
+
+    yield from _apply_patches(patches)

--- a/tensorrt_llm/_torch/auto_deploy/export/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/interface.py
@@ -5,7 +5,7 @@ This module defines the base classes and interfaces for all export patches.
 
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Type, Union, final
+from typing import Any, Callable, Dict, List, Type, Union, final
 
 from pydantic import BaseModel, Field
 
@@ -206,7 +206,7 @@ class ExportPatchRegistry:
         return patch_cls(config)
 
     @classmethod
-    def list_patches(cls) -> list[str]:
+    def list_patches(cls) -> List[str]:
         """List all registered patch names."""
         return list(cls._registry.keys())
 

--- a/tensorrt_llm/_torch/auto_deploy/export/library/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/library/__init__.py
@@ -1,0 +1,16 @@
+"""AutoDeploy's library of export patches.
+
+This file ensures that all publicly listed files/patches in the library folder are auto-imported
+and the corresponding patches are registered.
+"""
+
+import importlib
+import pkgutil
+
+__all__ = []
+
+for _, module_name, is_pkg in pkgutil.iter_modules(__path__):
+    if module_name.startswith("_"):
+        continue
+    __all__.append(module_name)
+    importlib.import_module(f"{__name__}.{module_name}")

--- a/tensorrt_llm/_torch/auto_deploy/export/library/autocast_noop.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/library/autocast_noop.py
@@ -1,0 +1,28 @@
+"""Patch to make torch.autocast a no-op during export."""
+
+from contextlib import nullcontext
+
+import torch
+
+from ..interface import BaseExportPatch, ExportPatchRegistry
+
+
+@ExportPatchRegistry.register("autocast_noop")
+class AutocastNoopPatch(BaseExportPatch):
+    """Patch torch.autocast to be a no-op during export.
+
+    This patch replaces torch.autocast with a null context manager
+    that can interfere with export.
+    """
+
+    def _apply_patch(self):
+        """Apply the autocast no-op patch."""
+        # Store original function
+        self.original_values["torch.autocast"] = torch.autocast
+
+        # Apply patch
+        torch.autocast = lambda *args, **kwargs: nullcontext()
+
+    def _revert_patch(self):
+        """Revert the autocast no-op patch."""
+        torch.autocast = self.original_values["torch.autocast"]

--- a/tensorrt_llm/_torch/auto_deploy/export/library/linear.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/library/linear.py
@@ -1,0 +1,35 @@
+"""Patch for F.linear to use simpler implementation during export."""
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+from ..interface import BaseExportPatch, ExportPatchRegistry
+
+
+@ExportPatchRegistry.register("linear")
+class LinearPatch(BaseExportPatch):
+    """Patch F.linear to use a simpler implementation for export.
+
+    This patch replaces F.linear with a version that avoids exporting
+    view operations used to flatten/unflatten multiple batch dimensions.
+    """
+
+    def _apply_patch(self):
+        """Apply the linear patch."""
+        # Store original function
+        self.original_values["F.linear"] = F.linear
+
+        # Create patched function
+        def _torch_linear_patch(
+            input: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor] = None
+        ) -> torch.Tensor:
+            return torch.ops.auto_deploy.torch_linear_simple(input, weight, bias)
+
+        # Apply patch
+        F.linear = _torch_linear_patch
+
+    def _revert_patch(self):
+        """Revert the linear patch."""
+        F.linear = self.original_values["F.linear"]

--- a/tensorrt_llm/_torch/auto_deploy/export/library/modelopt_context.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/library/modelopt_context.py
@@ -1,0 +1,23 @@
+"""Patch for modelopt's torch_export_context."""
+
+from contextlib import nullcontext
+
+from ..interface import ContextManagerPatch, ExportPatchRegistry
+
+
+@ExportPatchRegistry.register("modelopt_context")
+class ModeloptContextPatch(ContextManagerPatch):
+    """Patch to apply modelopt's torch_export_context during export.
+
+    This patch applies the modelopt quantization context manager around
+    the export process when available, otherwise uses a null context.
+    """
+
+    def init_context_manager(self):
+        """Initialize and return the modelopt context manager or nullcontext if not available."""
+        try:
+            from modelopt.torch.quantization.utils import export_torch_mode as torch_export_context
+
+            return torch_export_context()
+        except ImportError:
+            return nullcontext()

--- a/tensorrt_llm/_torch/auto_deploy/export/library/sdpa.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/library/sdpa.py
@@ -1,0 +1,27 @@
+"""Patch for F.scaled_dot_product_attention to use custom op."""
+
+import torch
+import torch.nn.functional as F
+
+from ..interface import BaseExportPatch, ExportPatchRegistry
+
+
+@ExportPatchRegistry.register("sdpa")
+class SdpaPatch(BaseExportPatch):
+    """Patch F.scaled_dot_product_attention to use custom op during export.
+
+    This patch ensures that scaled_dot_product_attention is represented consistently
+    in the exported graph by using a custom operation.
+    """
+
+    def _apply_patch(self):
+        """Apply the SDPA patch."""
+        # Store original function
+        self.original_values["F.scaled_dot_product_attention"] = F.scaled_dot_product_attention
+
+        # Apply patch
+        F.scaled_dot_product_attention = torch.ops.auto_deploy.torch_attention_sdpa
+
+    def _revert_patch(self):
+        """Revert the SDPA patch."""
+        F.scaled_dot_product_attention = self.original_values["F.scaled_dot_product_attention"]

--- a/tensorrt_llm/_torch/auto_deploy/export/library/sdpa_kernel_noop.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/library/sdpa_kernel_noop.py
@@ -1,0 +1,28 @@
+"""Patch to make torch.nn.attention.sdpa_kernel a no-op during export."""
+
+from contextlib import nullcontext
+
+import torch
+
+from ..interface import BaseExportPatch, ExportPatchRegistry
+
+
+@ExportPatchRegistry.register("sdpa_kernel_noop")
+class SdpaKernelNoopPatch(BaseExportPatch):
+    """Patch torch.nn.attention.sdpa_kernel to be a no-op during export.
+
+    This patch replaces torch.nn.attention.sdpa_kernel with a null context manager
+    that can interfere with export.
+    """
+
+    def _apply_patch(self):
+        """Apply the sdpa_kernel no-op patch."""
+        # Store original function
+        self.original_values["torch.nn.attention.sdpa_kernel"] = torch.nn.attention.sdpa_kernel
+
+        # Apply patch
+        torch.nn.attention.sdpa_kernel = lambda *args, **kwargs: nullcontext()
+
+    def _revert_patch(self):
+        """Revert the sdpa_kernel no-op patch."""
+        torch.nn.attention.sdpa_kernel = self.original_values["torch.nn.attention.sdpa_kernel"]

--- a/tensorrt_llm/_torch/auto_deploy/export/library/tensor_meta_device.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/library/tensor_meta_device.py
@@ -1,0 +1,33 @@
+"""Patch for torch.tensor to handle 0.0 on meta device."""
+
+import torch
+
+from ..interface import BaseExportPatch, ExportPatchRegistry
+
+
+@ExportPatchRegistry.register("tensor_meta_device")
+class TensorMetaDevicePatch(BaseExportPatch):
+    """Patch torch.tensor to handle 0.0 on meta device.
+
+    This patch addresses an issue where torch.tensor(0.0, device="meta")
+    doesn't work and needs to be replaced with torch.zeros((), device="meta").
+    """
+
+    def _apply_patch(self):
+        """Apply the tensor meta device patch."""
+        # Store original function
+        self.original_values["torch.tensor"] = torch.tensor
+
+        # Create patched function
+        def _torch_tensor_patch(data, **kwargs):
+            device = kwargs.get("device", None)
+            if data == 0.0 and device is not None and torch.device(device) == torch.device("meta"):
+                return torch.zeros((), **kwargs)
+            return self.original_values["torch.tensor"](data, **kwargs)
+
+        # Apply patch
+        torch.tensor = _torch_tensor_patch
+
+    def _revert_patch(self):
+        """Revert the tensor meta device patch."""
+        torch.tensor = self.original_values["torch.tensor"]

--- a/tensorrt_llm/_torch/auto_deploy/export/library/torch_modulelist_getitem.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/library/torch_modulelist_getitem.py
@@ -1,0 +1,43 @@
+"""Patch for nn.ModuleList.__getitem__ to handle slicing during export."""
+
+import torch.nn as nn
+
+from ..interface import BaseExportPatch, ExportPatchRegistry
+
+
+@ExportPatchRegistry.register("torch_modulelist_getitem")
+class TorchModuleListGetitemPatch(BaseExportPatch):
+    """Patch nn.ModuleList.__getitem__ to handle slicing during export.
+
+    This patch addresses a PyTorch issue where nn.ModuleList.__getitem__ with slice
+    indexing doesn't work correctly during export. The workaround returns a simple
+    list for slice operations.
+
+    Reference: https://github.com/pytorch/pytorch/issues/142439
+    """
+
+    def _apply_patch(self):
+        """Apply the ModuleList getitem patch."""
+        # Store original function
+        self.original_values["nn.ModuleList.__getitem__"] = nn.ModuleList.__getitem__
+
+        # Capture the original function for use in closure
+        original_getitem = nn.ModuleList.__getitem__
+
+        # Create patched function
+        def _torch_modulelist_getitem_patch(self: nn.ModuleList, idx):
+            if isinstance(idx, slice):
+                # return a simple list.
+                # NOTE: this obviously only works for any use case where we access the sliced module list
+                # like a regular list like a for-loop. For most other things, this hack will not work.
+                return list(self._modules.values())[idx]
+            else:
+                # Call the original function
+                return original_getitem(self, idx)
+
+        # Apply patch (type ignore needed as return type differs for slice case)
+        nn.ModuleList.__getitem__ = _torch_modulelist_getitem_patch  # type: ignore
+
+    def _revert_patch(self):
+        """Revert the ModuleList getitem patch."""
+        nn.ModuleList.__getitem__ = self.original_values["nn.ModuleList.__getitem__"]

--- a/tensorrt_llm/_torch/auto_deploy/export/library/torch_where.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/library/torch_where.py
@@ -1,0 +1,33 @@
+"""Patch for torch.where to handle case where only condition is provided."""
+
+import torch
+
+from ..interface import BaseExportPatch, ExportPatchRegistry
+
+
+@ExportPatchRegistry.register("torch_where")
+class TorchWherePatch(BaseExportPatch):
+    """Patch torch.where to handle the case where only condition is provided.
+
+    This patch addresses the issue where torch.where(condition) should return
+    torch.nonzero(condition, as_tuple=True) but the export process doesn't
+    handle this correctly.
+    """
+
+    def _apply_patch(self):
+        """Apply the torch.where patch."""
+        # Store original function
+        self.original_values["torch.where"] = torch.where
+
+        # Create patched function
+        def _torch_where_patch(condition: torch.Tensor, *args, **kwargs):
+            if len(args) == 0 and len(kwargs) == 0:
+                return torch.nonzero(condition, as_tuple=True)
+            return self.original_values["torch.where"](condition, *args, **kwargs)
+
+        # Apply patch
+        torch.where = _torch_where_patch
+
+    def _revert_patch(self):
+        """Revert the torch.where patch."""
+        torch.where = self.original_values["torch.where"]

--- a/tensorrt_llm/_torch/auto_deploy/export/library/transformers_sdpa_mask.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/library/transformers_sdpa_mask.py
@@ -1,0 +1,78 @@
+"""Patch for transformers SDPA mask to be export-compatible."""
+
+import importlib.metadata
+
+from packaging import version
+
+from ..interface import BaseExportPatch, ExportPatchRegistry
+
+
+def _transformers_version() -> str:
+    """Get the version of transformers."""
+    return version.parse(importlib.metadata.version("transformers")).base_version
+
+
+@ExportPatchRegistry.register("transformers_sdpa_mask")
+class TransformersSdpaMaskPatch(BaseExportPatch):
+    """Patch transformers.masking_utils.sdpa_mask to be export-compatible.
+
+    This patch replaces the transformers SDPA mask implementation with an
+    export-compatible version for transformers >= 4.53.0.
+    """
+
+    def _apply_patch(self):
+        """Apply the transformers SDPA mask patch."""
+        # this patch is only needed+compatible for transformers >= 4.53.0
+        if version.parse(_transformers_version()) < version.parse("4.53.0"):
+            return  # Skip patch for older versions
+
+        try:
+            # imports only after version check
+            from transformers import masking_utils
+            from transformers.integrations.executorch import sdpa_mask_without_vmap
+
+            # recall original implementation
+            self.original_values["masking_utils.sdpa_mask"] = masking_utils.sdpa_mask
+
+            # patch function and mask attention interface
+            masking_utils.sdpa_mask = sdpa_mask_without_vmap
+
+            if "sdpa" in masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._local_mapping:
+                self.original_values["sdpa_local_original"] = (
+                    masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._local_mapping["sdpa"]
+                )
+            else:
+                self.original_values["sdpa_local_original"] = None
+
+            masking_utils.ALL_MASK_ATTENTION_FUNCTIONS["sdpa"] = sdpa_mask_without_vmap
+
+        except ImportError:
+            # If transformers is not available or doesn't have required modules, skip patch
+            pass
+
+    def _revert_patch(self):
+        """Revert the transformers SDPA mask patch."""
+        # this patch is only needed+compatible for transformers >= 4.53.0
+        if version.parse(_transformers_version()) < version.parse("4.53.0"):
+            return  # Skip revert for older versions
+
+        try:
+            # imports only after version check
+            from transformers import masking_utils
+
+            # revert patches
+            if "masking_utils.sdpa_mask" in self.original_values:
+                masking_utils.sdpa_mask = self.original_values["masking_utils.sdpa_mask"]
+
+            if "sdpa_local_original" in self.original_values:
+                if self.original_values["sdpa_local_original"] is None:
+                    if "sdpa" in masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._local_mapping:
+                        del masking_utils.ALL_MASK_ATTENTION_FUNCTIONS["sdpa"]
+                else:
+                    masking_utils.ALL_MASK_ATTENTION_FUNCTIONS["sdpa"] = self.original_values[
+                        "sdpa_local_original"
+                    ]
+
+        except ImportError:
+            # If transformers is not available, skip revert
+            pass

--- a/tensorrt_llm/_torch/auto_deploy/models/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/__init__.py
@@ -1,7 +1,2 @@
-from . import hf
-from .decilm import *
-from .deepseek import *
+from . import hf, patches
 from .factory import *
-from .mixtral import *
-from .phi import *
-from .qwen3 import *

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/__init__.py
@@ -1,0 +1,16 @@
+"""AutoDeploy's library of export patches for models.
+
+This file ensures that all publicly listed files/patches in the library folder are auto-imported
+and the corresponding patches are registered.
+"""
+
+import importlib
+import pkgutil
+
+__all__ = []
+
+for _, module_name, is_pkg in pkgutil.iter_modules(__path__):
+    if module_name.startswith("_"):
+        continue
+    __all__.append(module_name)
+    importlib.import_module(f"{__name__}.{module_name}")

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/decilm.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/decilm.py
@@ -12,4 +12,5 @@ def _from_pretrained_patched(pretrained_model_name_or_path, **kwargs):
     return _orig_from_pretrained(pretrained_model_name_or_path, **kwargs)
 
 
+# TODO: figure out how this can be incorporated into the export patch system
 AutoConfig.from_pretrained = _from_pretrained_patched

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/deepseek.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/deepseek.py
@@ -181,4 +181,5 @@ def get_model_from_config_patched(config, **kwargs):
     return model
 
 
+# TODO: figure out how this can be incorporated into the export patch system
 AutoModelForCausalLM.from_config = get_model_from_config_patched

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/phi.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/phi.py
@@ -173,4 +173,5 @@ def get_model_from_config_patched(config, **kwargs):
     return model
 
 
+# TODO: figure out how this can be incorporated into the export patch system
 AutoModelForCausalLM.from_config = get_model_from_config_patched

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_gm.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_gm.py
@@ -1,13 +1,13 @@
 """A simple wrapper transform to export a model to a graph module."""
 
-from typing import Tuple, Type
+from typing import List, Optional, Tuple, Type
 
 from pydantic import Field
 from torch.fx import GraphModule
 
+from ...export import torch_export_to_gm
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
-from ...transformations.export import torch_export_to_gm
 from ..interface import BaseTransform, TransformConfig, TransformInfo, TransformRegistry
 
 
@@ -25,6 +25,11 @@ class ExportToGMConfig(TransformConfig):
         description="Whether to clone the state_dict of the model. This is useful to avoid"
         "modifying the original state_dict of the model.",
         default=False,
+    )
+    patch_list: Optional[List[str]] = Field(
+        description="List of patch names to apply with export. "
+        "Default is to apply all registered patches.",
+        default=None,
     )
 
 
@@ -57,6 +62,7 @@ class ExportToGM(BaseTransform):
             dynamic_shapes=cm.dynamic_shapes,
             clone=self.config.clone_state_dict,
             strict=self.config.strict,
+            patch_list=self.config.patch_list,
         )
 
         # this is a clean graph by definition since it was just exported

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/visualization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/visualization.py
@@ -5,11 +5,10 @@ from typing import Tuple
 
 import model_explorer
 import torch
+import torch.export as te
 from model_explorer.graph_builder import GraphNode, KeyValue, MetadataItem
 from model_explorer.pytorch_exported_program_adater_impl import PytorchExportedProgramAdapterImpl
 from torch import fx
-
-from ..export import torch_export
 
 
 def print_tensor(self, tensor: torch.Tensor, size_limit: int = 16):
@@ -79,7 +78,7 @@ CUSTOM_OPS = (
 
 # TODO(yudong): make viz as non-block call.
 def visualize_namespace(gm: fx.GraphModule, args: Tuple[torch.Tensor, ...], dynamic_shapes):
-    ep = torch_export(gm, args=args, dynamic_shapes=dynamic_shapes)
+    ep = te.export(gm, args=args, dynamic_shapes=dynamic_shapes)
     graph = ep.graph
     # Ensure the ops land up in the right module for better viz
     for n in graph.nodes:

--- a/tensorrt_llm/_torch/auto_deploy/utils/pattern_matcher.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/pattern_matcher.py
@@ -30,7 +30,7 @@ from torch._inductor.pattern_matcher import (
 )
 from torch.fx import GraphModule
 
-from tensorrt_llm._torch.auto_deploy.transformations.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 
 
 @contextlib.contextmanager

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_graph_test_helpers.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_graph_test_helpers.py
@@ -5,9 +5,10 @@ import numpy as np
 import torch
 import torch.nn as nn
 from _torch_test_utils import all_close, reset_parameters
+from torch.export import export
 from torch.fx import GraphModule
 
-from tensorrt_llm._torch.auto_deploy.transformations.export import torch_export, torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transformations.library.sharding import ShardingTransformInfo
 
 
@@ -112,7 +113,7 @@ def run_test(
         torch.testing.assert_close(y_model, y_loaded_from_transformed, atol=atol, rtol=rtol)
 
     # check if we can still export the model as expected
-    torch_export(gm, args=(x,))
+    export(gm, args=(x,))
 
     # return graph module for further testing
     return gm

--- a/tests/unittest/_torch/auto_deploy/integration/test_llama4_vlm_export.py
+++ b/tests/unittest/_torch/auto_deploy/integration/test_llama4_vlm_export.py
@@ -8,8 +8,8 @@ from transformers import AutoConfig, AutoProcessor, Llama4ForConditionalGenerati
 from transformers.models.llama4.modeling_llama4 import Llama4CausalLMOutputWithPast
 from utils.llm_data import llm_models_root
 
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transformations._graph import move_to_device
-from tensorrt_llm._torch.auto_deploy.transformations.export import torch_export_to_gm
 
 
 # Copy from https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/modeling_llama4.py#L1651

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_allreduce_residual_rmsnorm_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_allreduce_residual_rmsnorm_fusion.py
@@ -3,10 +3,11 @@
 import pytest
 import torch
 from _dist_test_utils import get_device_counts
+from torch.export import export
 
 from tensorrt_llm._torch.auto_deploy.distributed import common as dist
 from tensorrt_llm._torch.auto_deploy.distributed.trtllm import is_trtllm_op_available
-from tensorrt_llm._torch.auto_deploy.transformations.export import torch_export, torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transformations.library.collectives import (
     fuse_allreduce_residual_rmsnorm,
 )
@@ -85,7 +86,7 @@ def _test_allreduce_fusion(port: int):
     )
 
     # check if we can still export the model as expected
-    torch_export(gm, args=args)
+    export(gm, args=args)
     torch_export_to_gm(gm, args=args)
 
 

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_graph_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_graph_sharding.py
@@ -11,7 +11,7 @@ from _dist_test_utils import get_device_counts
 from _graph_test_helpers import run_sharding_pattern_detection_test, run_test
 
 import tensorrt_llm._torch.auto_deploy.distributed.common as dist_common
-from tensorrt_llm._torch.auto_deploy.transformations.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transformations.library import (
     ShardingConfig,
     SplitDimension,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/compile/test_captured_graph.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/compile/test_captured_graph.py
@@ -8,7 +8,7 @@ from _model_test_utils import (
 
 from tensorrt_llm._torch.auto_deploy.compile.backends.torch_cudagraph import CapturedGraph
 from tensorrt_llm._torch.auto_deploy.compile.compiler import _flatten_args
-from tensorrt_llm._torch.auto_deploy.transformations.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 
 
 class ModelWithMultipleInputs(torch.nn.Module):

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/compile/test_compiler.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/compile/test_compiler.py
@@ -8,7 +8,7 @@ from _model_test_utils import (
 from torch.nn import Module
 
 from tensorrt_llm._torch.auto_deploy.compile import compile_and_capture
-from tensorrt_llm._torch.auto_deploy.transformations.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 
 
 @pytest.mark.parametrize(

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
@@ -8,7 +8,7 @@ from _model_test_utils import _hf_model_dir_or_hub_id
 from transformers import AutoConfig, AutoModelForCausalLM
 from utils.llm_data import llm_models_root
 
-from tensorrt_llm._torch.auto_deploy.models.deepseek import (
+from tensorrt_llm._torch.auto_deploy.models.patches.deepseek import (
     deepseek_v3_attention,
     deepseek_v3_moe_exact,
 )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
@@ -77,6 +77,7 @@ def test_match_llama_attention(config: Dict[str, Any], attn_implementation: str)
     dynamic_shapes = {0: Dim("batch_size", max=8), 1: Dim("seq_len", min=4, max=16)}
 
     model = HFWrapper(LlamaModel(LlamaConfig(**full_config))).to("cuda")
+    model.eval()
     x = torch.randint(
         0, full_config["vocab_size"], (batch_size, seq_len), dtype=torch.long, device="cuda"
     )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_kv_cache.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_kv_cache.py
@@ -9,10 +9,10 @@ from _torch_test_utils import all_close
 from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import CacheConfig, SequenceInfo
 from tensorrt_llm._torch.auto_deploy.custom_ops.flashinfer_attention import FlashInferAttention
 from tensorrt_llm._torch.auto_deploy.custom_ops.triton_attention import TritonAttention
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
 from tensorrt_llm._torch.auto_deploy.transform.interface import InferenceOptimizerConfig
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
-from tensorrt_llm._torch.auto_deploy.transformations.export import torch_export, torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transformations.library import update_in_out_nodes
 from tensorrt_llm._torch.auto_deploy.transformations.library.kvcache import insert_cached_attention
 
@@ -225,6 +225,5 @@ def test_sdpa_with_kv_cache(dtype, attn_descriptor, gqa_config):
     assert all_close(y_model, y_with_cache, atol=atol, rtol=rtol)
 
     # Test 4: Exportability of the transformed model
-    torch_export(gm, args=cm.args)
     exported_gm = torch_export_to_gm(gm, args=cm.args)
     assert exported_gm is not None

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quantization.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quantization.py
@@ -9,7 +9,7 @@ from _model_test_utils import MLP, BMMDynamicModel, BMMModel
 from _torch_test_utils import fp4_compatible, fp8_compatible
 
 from tensorrt_llm._torch.auto_deploy.custom_ops.quant import QUANT_OPS
-from tensorrt_llm._torch.auto_deploy.transformations.export import torch_export, torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transformations.library import quantize
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import fp8_scale
@@ -71,7 +71,6 @@ def test_quantization(quant_config, atol, rtol, num_p_og):
     # check there's quantization error during transformation
     assert not torch.allclose(model(x), gm_transformed(x))
     # check if we can still export the model as expected
-    torch_export(gm_transformed, args=(x,))
     torch_export_to_gm(gm_transformed, args=(x,))
 
 
@@ -142,5 +141,4 @@ def test_bmm_quantization(quant_config, atol, rtol, num_p_og, model_class):
     # check there's quantization error during transformation
     assert not torch.allclose(model(x), gm_transformed(x))
     # check if we can still export the model as expected
-    torch_export(gm_transformed, args=(x,))
     torch_export_to_gm(gm_transformed, args=(x,))

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/test_export.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/test_export.py
@@ -7,15 +7,15 @@ import torch.nn as nn
 import torch.nn.functional as F
 from _model_test_utils import MLP
 from _torch_test_utils import all_close
-from torch.export import Dim
+from torch.export import Dim, export
 from torch.fx import GraphModule
 
-from tensorrt_llm._torch.auto_deploy.transformations.export import torch_export, torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 
 
 def _torch_export_non_strict(model, *args, **kwargs):
     kwargs["strict"] = False
-    return torch_export(model, *args, **kwargs)
+    return export(model, *args, **kwargs)
 
 
 class ModuleForExport(ABC, nn.Module):
@@ -94,7 +94,7 @@ class ModuleWithWhere(ModuleForExport):
 
     def check_xfail(self, f_export, use_dynamic_shape, device) -> bool:
         return (
-            use_dynamic_shape and f_export in [torch_export, _torch_export_non_strict]
+            use_dynamic_shape and f_export in [export, _torch_export_non_strict]
         ) or device == "meta"
 
 
@@ -133,7 +133,7 @@ class ModuleWithRouting(ModuleForExport):
 
     def check_xfail(self, f_export, use_dynamic_shape, device) -> bool:
         return (
-            use_dynamic_shape and f_export in [torch_export, _torch_export_non_strict]
+            use_dynamic_shape and f_export in [export, _torch_export_non_strict]
         ) or device == "meta"
 
 
@@ -162,7 +162,7 @@ class ModuleWithModuleList(ModuleForExport):
 
 @pytest.mark.parametrize(
     "f_export",
-    [torch.export.export, torch_export, _torch_export_non_strict, torch_export_to_gm],
+    [torch.export.export, export, _torch_export_non_strict, torch_export_to_gm],
 )
 @pytest.mark.parametrize("use_dynamic_shape", [True, False])
 @pytest.mark.parametrize("device", ["cpu", "cuda", "meta"])


### PR DESCRIPTION
This PR provides a more modular system to handle the various export patches we have accumulated and provides an easy way to add new ones akin of the modular inference optimizer.

Note that I have also brought in our **model patches** into the new system