### PR TITLE
Revert "[None] Add sink/sliding window support for Triton"

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/_triton_attention_internal.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/_triton_attention_internal.py
@@ -100,8 +100,6 @@ def _paged_generate_mha(
         n_heads,
         d_head,
         SEQ_BLOCK_SIZE,
-        False,  # HAS_SINKS: no sink tokens used
-        None,  # sinks_ptr: no sink tokens used
     )
 
 
@@ -340,7 +338,6 @@ def _generate_mha_rope_fusion(
         d_head,
         SEQ_BLOCK_SIZE,
         HEAD_BLOCK_SIZE,
-        -1,  # SLIDING_WINDOW: -1 means no sliding window
     )
     attention_kv_stage2[(b, n_heads, 1)](
         stage1_output_values,
@@ -351,8 +348,6 @@ def _generate_mha_rope_fusion(
         n_heads,
         d_head,
         SEQ_BLOCK_SIZE,
-        False,  # HAS_SINKS: no sink tokens used
-        None,  # sinks_ptr: no sink tokens used
     )
 
 
@@ -419,9 +414,6 @@ def _flattened_context_mha_rope_fusion(
         d_head,
         SEQ_BLOCK,
         max_cache_seq_len,
-        -1,  # SLIDING_WINDOW: -1 means no sliding window
-        False,  # HAS_SINKS: no sink tokens used
-        None,  # sinks_ptr: no sink tokens used
         num_stages=2,
     )
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
@@ -41,8 +41,6 @@ def _generate_mha(
     input_pos: torch.Tensor,
     scale: float,
     out: torch.Tensor,
-    sinks: Optional[torch.Tensor] = None,
-    sliding_window: Optional[int] = None,
 ):
     b, (n_heads, q_d_head) = q.shape[0], q.shape[-2:]
     max_seq_len, n_kv_heads = k_cache.shape[1:3]
@@ -99,11 +97,7 @@ def _generate_mha(
         v_d_head,
         SEQ_BLOCK_SIZE,
         HEAD_BLOCK_SIZE,
-        sliding_window if sliding_window is not None else -1,
     )
-
-    has_sinks = sinks is not None
-
     attention_kv_stage2[(b, n_heads, 1)](
         stage1_output_values,
         stage1_output_logsumexp,
@@ -113,8 +107,6 @@ def _generate_mha(
         n_heads,
         v_d_head,
         SEQ_BLOCK_SIZE,
-        has_sinks,
-        sinks if has_sinks else None,
     )
 
 
@@ -130,8 +122,6 @@ def _flattened_context_mha(
     seq_start: torch.Tensor,
     scale: float,
     out: torch.Tensor,
-    sinks: Optional[torch.Tensor] = None,
-    sliding_window: Optional[int] = None,
 ) -> None:
     # NOTE: s_total == sum(seq_len)
     s_total, n_heads, q_d_head = q.shape
@@ -159,8 +149,6 @@ def _flattened_context_mha(
 
     # TODO: use input_pos to get the correct cache locations
     grid = (BATCH_SIZE, n_heads, (max(seq_len) + SEQ_BLOCK - 1) // SEQ_BLOCK)
-    has_sinks = sinks is not None
-
     context_attention_kv_flattened[grid](
         q,
         seq_len,
@@ -177,9 +165,7 @@ def _flattened_context_mha(
         v_d_head,
         SEQ_BLOCK,
         max_cache_seq_len,
-        sliding_window if sliding_window is not None else -1,
-        has_sinks,
-        sinks if has_sinks else None,
+        num_stages=2,
     )
 
 
@@ -201,8 +187,6 @@ def flattened_mha_with_cache(
     # <none>
     # CONSTANTS
     scale: Optional[float],
-    sinks: Optional[torch.Tensor] = None,
-    sliding_window: Optional[int] = None,
 ) -> torch.Tensor:
     """Flattened MHA with cache that takes q, k, v in BSND layout.
 
@@ -239,9 +223,7 @@ def flattened_mha_with_cache(
     y = q.new_empty(*bs_view, num_heads, v_head_dim).contiguous()
     if s == 1:
         # generate-only phase
-        _generate_mha(
-            q, k, v, k_cache, v_cache, cache_loc, input_pos, scale, y, sinks, sliding_window
-        )
+        _generate_mha(q, k, v, k_cache, v_cache, cache_loc, input_pos, scale, y)
     else:
         # mixed context + generate phase
         _flattened_context_mha(
@@ -256,8 +238,6 @@ def flattened_mha_with_cache(
             seq_start,
             scale,
             y,
-            sinks,
-            sliding_window,
         )
 
     return y.view(*output_shape)
@@ -275,8 +255,6 @@ def flattened_mha_fake(
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
     scale: Optional[float],
-    sinks: Optional[torch.Tensor] = None,
-    sliding_window: Optional[int] = None,
 ):
     return q.new_empty(*q.shape[:-1], v.shape[-1]).contiguous()
 
@@ -411,12 +389,6 @@ class TritonAttention(AttentionDescriptor):
             ad_logger.warning("Provided scale is not a float, Using default scale instead.")
             scale = None
 
-        # Get sinks and sliding_window from args or kwargs
-        sinks = extract_op_args(source_attn_node, "sinks")[0]
-        sliding_window = extract_op_args(source_attn_node, "sliding_window")[0]
-
         return [
             scale,  # softmax scale
-            sinks,
-            sliding_window,
         ]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_kernels/attention_with_kv_cache.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_kernels/attention_with_kv_cache.py
@@ -112,7 +112,6 @@ def gqa_attention_kv_stage1(
     V_D_HEAD: tl.constexpr,  # Dimension of each key/value head
     SEQ_BLOCK_SIZE: tl.constexpr,  # Block size used for tiling the sequence dim.
     HEAD_BLOCK_SIZE: tl.constexpr,  # pad to 16 if HEAD_RATIO is < 16 to invoke tensor cores.
-    SLIDING_WINDOW: tl.constexpr,  # Sliding window size, -1 means no sliding window
 ):
     """Attention kernel to be used for generate-only batches.
 
@@ -123,7 +122,7 @@ def gqa_attention_kv_stage1(
     Supports non-power-of-2 D_HEAD
 
     Uses flash decoding.
-    KV-cache layout is assumed to be [Batch, Seq, Head, Dim]
+    KV-cache layout is assumed to be [Batch,Seq, Head, Dim]
     1. Fetch the K-cache from 0 to input_pos
     2. Fetch the V-cache from 0 to input_pos
     3. A = Q*K^T [1,D_HEAD] * [1,seq_len,D_HEAD] -> [1, seq_len]
@@ -146,21 +145,10 @@ def gqa_attention_kv_stage1(
 
     # The number of Q heads that map to each KV head.
     HEAD_RATIO: tl.constexpr = N_HEADS // N_KV_HEADS  # This needs to be a power-of-2
-
-    # Apply sliding window constraints
-    if SLIDING_WINDOW > 0:
-        # For sliding window, limit the sequence range
-        sliding_start = tl.maximum(0, kv_position - SLIDING_WINDOW + 1)
-        if seq_start_pos + SEQ_BLOCK_SIZE <= sliding_start or seq_start_pos > kv_position:
-            return
-        seq_offsets = seq_start_pos + tl.arange(0, SEQ_BLOCK_SIZE)
-        seq_mask = (seq_offsets <= kv_position) & (seq_offsets >= sliding_start)
-    else:
-        # No sliding window, use original logic
-        if seq_start_pos > kv_position:
-            return
-        seq_offsets = seq_start_pos + tl.arange(0, SEQ_BLOCK_SIZE)
-        seq_mask = seq_offsets <= kv_position
+    if seq_start_pos > kv_position:
+        return
+    seq_offsets = seq_start_pos + tl.arange(0, SEQ_BLOCK_SIZE)
+    seq_mask = seq_offsets <= kv_position
 
     # Need to pad the head dim to 16 if HEAD_RATIO is < 16 so that tensor cores can be invoked
     #
@@ -370,8 +358,6 @@ def attention_kv_stage2(
     N_HEADS: tl.constexpr,
     D_HEAD: tl.constexpr,
     SEQ_BLOCK_SIZE: tl.constexpr,  # Nearest power of 2 for num_blocks
-    HAS_SINKS: tl.constexpr,
-    sinks_ptr,
 ):
     # There are batch * N_HEADS programs
     batch_id = tl.program_id(axis=0)
@@ -396,11 +382,6 @@ def attention_kv_stage2(
     sumexp = tl.exp(logsumexp - max_logsumexp)  # [NUM_BLOCKS_POW2]
 
     aggregate_sumexp = tl.sum(sumexp, axis=0)
-    # Add sinks contribution to the softmax denominator
-    if HAS_SINKS:
-        sinks_val = tl.load(sinks_ptr + batch_id * N_HEADS + head_id)
-        sinks_exp = tl.exp(sinks_val - max_logsumexp)
-        aggregate_sumexp += sinks_exp
 
     values_offsets = block_offsets[:, None] * D_HEAD + dhead_offsets[None, :]
     values_mask = block_mask[:, None] * dhead_mask[None, :]
@@ -592,9 +573,6 @@ def context_attention_kv_flattened(
     V_D_HEAD: tl.constexpr,  # Dimension of each value head.
     SEQ_BLOCK: tl.constexpr,
     MAX_SEQ_LENGTH: tl.constexpr,
-    SLIDING_WINDOW: tl.constexpr,  # Sliding window size, -1 means no sliding window
-    HAS_SINKS: tl.constexpr,
-    sinks_ptr,
 ):
     """Kernel for context phase.
 
@@ -645,12 +623,6 @@ def context_attention_kv_flattened(
     # input_pos_ptr stores the location at which kv must be written back for the given batch.
     kv_position = tl.load(input_pos_ptr + batch_id)
     num_blocks = (kv_position + seq_len + SEQ_BLOCK - 1) // SEQ_BLOCK
-    # Apply sliding window constraints if enabled
-    if SLIDING_WINDOW > 0:
-        # Calculate sliding window range for each token in the current block
-        min_kv_position = tl.maximum(0, kv_position + seq_offsets - SLIDING_WINDOW + 1)
-        max_kv_position = kv_position + seq_offsets
-
     for s in range(0, num_blocks + 1, 1):
         kv_seq_offsets = s * SEQ_BLOCK + tl.arange(0, SEQ_BLOCK)
         kv_seq_mask = kv_seq_offsets < (kv_position + seq_len)
@@ -665,32 +637,13 @@ def context_attention_kv_flattened(
         )
         qk = tl.zeros([SEQ_BLOCK, SEQ_BLOCK], dtype=tl.float32)
         qk += tl.dot(q, k.trans())
-
-        # Apply both causal and sliding window masks
-        causal_mask = (seq_offsets[:, None] + kv_position) >= kv_seq_offsets[None, :]
-        if SLIDING_WINDOW > 0:
-            sliding_mask = (kv_seq_offsets[None, :] >= min_kv_position[:, None]) & (
-                kv_seq_offsets[None, :] <= max_kv_position[:, None]
-            )
-            combined_mask = causal_mask & sliding_mask
-        else:
-            combined_mask = causal_mask
-
-        qk = tl.where(combined_mask, qk, float("-inf"))
-
+        qk = tl.where(
+            (seq_offsets[:, None] + kv_position) >= kv_seq_offsets[None, :], qk, float("-inf")
+        )
         qk *= SCALE
-
-        # Check if any valid attention weights exist for each query token
-        has_valid_attn = tl.sum(combined_mask.to(tl.int32), axis=1) > 0
-
         # rowmax
         m_ij = tl.maximum(tl.max(qk, 1), lse_i)
-        # For rows with no valid attention, set m_ij to 0 to avoid NaN
-        m_ij = tl.where(has_valid_attn, m_ij, 0.0)
-
         p = tl.exp(qk - m_ij[:, None])
-        # Set exp values to 0 for rows with no valid attention
-        p = tl.where(has_valid_attn[:, None], p, 0.0)
         v = tl.load(
             v_cache_ptr
             + cache_batch_offset * V_D_HEAD
@@ -708,16 +661,6 @@ def context_attention_kv_flattened(
         m_i = m_ij
         l_i_new = tl.exp(lse_i - m_ij) + l_ij
         lse_i = m_ij + tl.log(l_i_new)
-
-    # Add sinks contribution to the final softmax calculation
-    if HAS_SINKS:
-        sinks_val = tl.load(sinks_ptr + batch_id * N_HEADS + head_id)
-        m_sinks = tl.maximum(m_i, sinks_val)
-        acc_scale = tl.exp(m_i - m_sinks)
-        acc = acc * acc_scale[:, None]
-        l_sinks = tl.exp(lse_i - m_sinks) + tl.exp(sinks_val - m_sinks)
-        lse_i = m_sinks + tl.log(l_sinks)
-        m_i = m_sinks
 
     o_scale = tl.exp(m_i - lse_i)
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/triton_kernels/test_attention_with_kv_cache.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/triton_kernels/test_attention_with_kv_cache.py
@@ -18,16 +18,10 @@ from tensorrt_llm._torch.auto_deploy.custom_ops.triton_kernels.attention_with_kv
 )
 
 
-def torch_reference_stage2(values, logsumexp, sinks=None):
+def torch_reference_stage2(values, logsumexp):
     max_logsumexp = torch.max(logsumexp, axis=-1, keepdim=True)[0]  # [b, n_heads, 1]
     sumexp = torch.exp(logsumexp - max_logsumexp)  # [b, n_heads, num_blocks]
     aggregate_sumexp = torch.sum(sumexp, axis=-1)  # [b, n_heads]
-
-    # Add sinks contribution to the softmax denominator
-    if sinks is not None:
-        sinks_exp = torch.exp(sinks - max_logsumexp.squeeze(-1))  # [b, n_heads]
-        aggregate_sumexp += sinks_exp
-
     output = values * sumexp[:, :, :, None]  # [b, n_heads, num_blocks, d_head]
     output = output / aggregate_sumexp[:, :, None, None]
     output = torch.sum(output, axis=2)
@@ -204,8 +198,7 @@ def test_attention_kv_flash_decoding(d_head):
 @pytest.mark.parametrize("q_d_head", [16, 96])
 @pytest.mark.parametrize("v_d_head", [16, 96])
 @pytest.mark.parametrize("n_heads,n_kv_heads", [(8, 8), (8, 1)])
-@pytest.mark.parametrize("sliding_window", [-1, 16])
-def test_gqa_attention_kv_flash_decoding(q_d_head, v_d_head, n_heads, n_kv_heads, sliding_window):
+def test_gqa_attention_kv_flash_decoding(q_d_head, v_d_head, n_heads, n_kv_heads):
     DEVICE = "cuda"
     DTYPE = torch.float16
     BATCH_SIZE = 64
@@ -278,12 +271,10 @@ def test_gqa_attention_kv_flash_decoding(q_d_head, v_d_head, n_heads, n_kv_heads
             V_D_HEAD,
             SEQ_BLOCK_SIZE,
             HEAD_BLOCK_SIZE,
-            sliding_window,  # SLIDING_WINDOW: parameterized
         )
 
     run(q, k_cache, v_cache, output_tensor, output_logsumexp)
     # This needs to be another kernel if torch-trt doesn't support broadcast + div.
-    print(output_tensor, output_tensor.shape)
     output = torch_reference_stage2(output_tensor, output_logsumexp)
 
     ref = []
@@ -310,8 +301,7 @@ def test_gqa_attention_kv_flash_decoding(q_d_head, v_d_head, n_heads, n_kv_heads
     )
 
 
-@pytest.mark.parametrize("has_sinks", [False, True])
-def test_attention_with_kv_stage2(has_sinks):
+def test_attention_with_kv_stage2():
     DEVICE = "cuda"
     BATCH_SIZE = 4
     N_HEADS = 32
@@ -325,11 +315,6 @@ def test_attention_with_kv_stage2(has_sinks):
     )
     logsumexp = torch.randn(BATCH_SIZE, N_HEADS, num_blocks, device=DEVICE, dtype=torch.float32)
     output = torch.zeros(BATCH_SIZE, N_HEADS, D_HEAD, device=DEVICE, dtype=torch.float32)
-
-    # Create sink tokens if needed - kernel expects [BATCH_SIZE, N_HEADS] shape
-    sinks = (
-        torch.randn(BATCH_SIZE, N_HEADS, device=DEVICE, dtype=torch.float32) if has_sinks else None
-    )
 
     def run():
         attention_kv_stage2[
@@ -346,20 +331,15 @@ def test_attention_with_kv_stage2(has_sinks):
             N_HEADS,
             D_HEAD,
             SEQ_BLOCK_SIZE,
-            has_sinks,  # HAS_SINKS: parameterized
-            sinks,  # sinks_ptr: sink tokens tensor or None
         )
 
     run()
     ref = []
     for i in range(BATCH_SIZE):
         block_id = input_positions[i].item() // SEQ_BLOCK_SIZE + 1
-        batch_sinks = sinks[i : i + 1, :] if has_sinks else None  # [1, N_HEADS]
         ref.append(
             torch_reference_stage2(
-                values[i, :, :block_id, :].unsqueeze(0),
-                logsumexp[i, :, :block_id].unsqueeze(0),
-                batch_sinks,
+                values[i, :, :block_id, :].unsqueeze(0), logsumexp[i, :, :block_id].unsqueeze(0)
             )
         )
     ref = torch.cat(ref, dim=0)
@@ -426,6 +406,7 @@ def test_context_attention_kv(batch_size, q_d_head, v_d_head, n_heads, n_kv_head
         V_D_HEAD,
         SEQ_BLOCK,
         MAX_SEQ_LEN,
+        num_stages=2,
     )
 
     if N_HEADS != N_KV_HEADS:
@@ -444,10 +425,7 @@ def test_context_attention_kv(batch_size, q_d_head, v_d_head, n_heads, n_kv_head
 @pytest.mark.parametrize("n_heads,n_kv_heads", [(8, 8), (8, 1)])
 @pytest.mark.parametrize("q_d_head", [32, 96])
 @pytest.mark.parametrize("v_d_head", [32, 96])
-@pytest.mark.parametrize("sliding_window", [-1, 16])
-def test_context_attention_kv_flattened(
-    q_d_head, v_d_head, n_heads, n_kv_heads, dtype, sliding_window
-):
+def test_context_attention_kv_flattened(q_d_head, v_d_head, n_heads, n_kv_heads, dtype):
     DEVICE = "cuda"
     DTYPE = getattr(torch, dtype)
     N_HEADS = n_heads
@@ -490,34 +468,10 @@ def test_context_attention_kv_flattened(
                 kk = repeat_kv(q[i], kk)
                 vv = repeat_kv(q[i], vv)
 
-            # Create causal mask
             mask = torch.tril(
                 torch.ones(q[i].shape[1], kk.shape[1], dtype=torch.bool),
                 diagonal=kk.shape[1] - q[i].shape[1],
             )
-
-            # Apply sliding window constraints if enabled
-            if sliding_window > 0:
-                seq_len_q = q[i].shape[1]  # Current sequence length
-                seq_len_k = kk.shape[1]  # Total KV sequence length
-
-                # Create sliding window mask
-                sliding_mask = torch.zeros_like(mask)
-                for q_pos in range(seq_len_q):
-                    # For each query position, determine its absolute position in the cache
-                    abs_q_pos = INPUT_POS[i] + q_pos
-                    # Calculate sliding window range
-                    sliding_start = max(0, abs_q_pos - sliding_window + 1)
-                    sliding_end = abs_q_pos + 1
-                    # Apply to KV cache positions
-                    k_start = max(0, sliding_start)
-                    k_end = min(seq_len_k, sliding_end)
-                    if k_start < k_end:
-                        sliding_mask[q_pos, k_start:k_end] = True
-
-                # Combine causal and sliding window masks
-                mask = mask & sliding_mask
-
             ref.append(
                 torch.nn.functional.scaled_dot_product_attention(
                     q[i].transpose(1, 2),
@@ -581,11 +535,8 @@ def test_context_attention_kv_flattened(
         V_D_HEAD,
         SEQ_BLOCK,
         MAX_SEQ_LEN,
-        sliding_window,  # SLIDING_WINDOW: parameterized
-        False,  # HAS_SINKS: no sink tokens used
-        None,  # sinks_ptr: no sink tokens used
+        num_stages=2,
     )
-
     assert torch.allclose(ref, output_tensor, atol=1e-2, rtol=1e-2)
 
 


### PR DESCRIPTION
Reverts nv-auto-deploy/TensorRT-LLM#77


I am getting a couple of cuda device assertions when running the unit tests - I am assuming it is related to the numerical stability of the updated triton kernel