### PR TITLE
[Reopen #88]Attention Pattern Matcher with torch._inductor pattern matcher

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
@@ -96,23 +96,24 @@ def named_graphmodules(gm: fx.GraphModule) -> Iterator[Tuple[str, fx.GraphModule
             yield name, m
 
 
-def _move_single_gm_to_device(
-    gm: GraphModule, device: torch.device, recompile_graph: bool = False
-) -> None:
+def _move_single_gm_to_device(gm: GraphModule, device: torch.device) -> None:
     """Move one GraphModule and its nodes to the specified device in-place.
     Partially inspired by https://github.com/pytorch/pytorch/blob/05cb98f91d49df9eadfcb3fc29bbd1b621d88860/torch/export/passes/__init__.py#L11
     """
     # move state dict
     gm.to(device)
+    recompile_graph = False
 
     for node in gm.graph.nodes:
         # move all the nodes kwargs with burnt-in device
         if "device" in node.kwargs:
+            recompile_graph = True
             kwargs = node.kwargs.copy()
             kwargs["device"] = device
             node.kwargs = kwargs
 
         if is_op(node, torch.ops.aten.to.device):
+            recompile_graph = True
             args = list(node.args)
             args[1] = device
             node.args = tuple(args)
@@ -135,7 +136,7 @@ def move_to_device(gm: fx.GraphModule, device: DeviceLikeType) -> fx.GraphModule
 
     for _, subgm in reversed(list(named_graphmodules(gm))):
         # recompile graph to update self generated codes in subgraph
-        _move_single_gm_to_device(subgm, device, subgm is not gm)
+        _move_single_gm_to_device(subgm, device)
 
 
 def _is_impure_node(node: Node) -> bool:

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/attention.py
@@ -1,746 +1,312 @@
-"""Pattern matching for detecting repeat_kv pattern from Huggingface models."""
+"""Pattern matching for detecting eager and grouped attention pattern from Huggingface models."""
 
-from typing import Dict, Optional, Type
+from contextlib import nullcontext
+from typing import Any, Callable, Dict, List, Type
 
 import torch
-from torch.fx import GraphModule, Node
+import torch.nn.functional as F
+from torch.fx import GraphModule
 
 from ...custom_ops.attention_interface import AttentionDescriptor
 from ...utils.logger import ad_logger
 from ...utils.node_utils import is_op
-from .._graph import canonicalize_graph
+from ...utils.pattern_matcher import ADPatternMatcherPass, register_ad_pattern
+from .._graph import canonicalize_graph, lift_to_meta
 
 
-def match_repeat_kv(gm: GraphModule) -> None:
+def _apply_pattern(
+    gm: GraphModule,
+    pattern_name: str,
+    register_fn: Callable[[ADPatternMatcherPass], None],
+    shape_prop: bool = False,
+) -> None:
+    """Utility to register and apply a pattern."""
+    patterns = ADPatternMatcherPass()
+    register_fn(patterns)
+    num_matches = patterns.apply(gm.graph)
+
+    if num_matches > 0:
+        with lift_to_meta(gm) if shape_prop else nullcontext():
+            canonicalize_graph(gm, shape_prop=shape_prop)
+    ad_logger.info(f"Found and matched {num_matches} {pattern_name} pattern(s)")
+
+
+def match_attention_pattern(gm: GraphModule) -> None:
     """
-    Match and replace the repeat_kv pattern in fx graphs.
+    Match and replace attention patterns in the graph.
 
-    The pattern is:
-    unsqueeze -> expand -> reshape -> [optional] contiguous
-
-    This is replaced with torch.ops.auto_deploy.torch_attention_repeat_kv.
+    This transformation detects both eager (ungrouped) and grouped attention patterns,
+    and replaces them with `torch.ops.auto_deploy.torch_attention_grouped_sdpa`.
     """
-    graph = gm.graph
 
-    num_kv_patterns = 0
-
-    # Iterate through nodes in the graph
-    for node in list(graph.nodes):
-        # Look for reshape nodes that could be the end of our pattern
-        if is_op(node, torch.ops.aten.reshape):
-            match_info = _match_repeat_kv_pattern(node)
-            if match_info:
-                ad_logger.debug(f"Found repeat_kv pattern at {node}")
-                _replace_with_repeat_kv(graph, match_info)
-                num_kv_patterns += 1
-
-    # Clean up the graph if we made any replacements
-    if num_kv_patterns:
-        canonicalize_graph(gm)
-    ad_logger.info(f"Found {num_kv_patterns} repeat_kv patterns")
-
-
-def match_eager_attention(gm: GraphModule) -> None:
-    """
-    Match and replace the eager attention pattern in fx graphs.
-
-    The pattern is:
-    transpose -> matmul -> mul -> (optional) add -> softmax -> to -> dropout -> matmul
-
-    This is replaced with torch.ops.auto_deploy.torch_attention_sdpa.
-    """
-    graph = gm.graph
-
-    # Track replacements to avoid processing nodes multiple times
-    num_eager_patterns = 0
-
-    # Iterate through nodes in the graph
-    for node in list(graph.nodes):
-        # Look for the final matmul nodes that could be part of our pattern
-        if is_op(node, torch.ops.aten.matmul):
-            match_info = _match_eager_attention_pattern(node)
-            if match_info:
-                ad_logger.debug(f"Found eager attention pattern at {node}")
-                _replace_with_sdpa(graph, match_info)
-                num_eager_patterns += 1
-
-    # Clean up the graph if we made any replacements
-    if num_eager_patterns:
-        canonicalize_graph(gm)
-    ad_logger.info(f"Found {num_eager_patterns} eager attention patterns")
-
-
-def match_grouped_attention(gm: GraphModule) -> None:
-    """
-    Match and replace the grouped attention pattern in fx graphs.
-
-    The pattern is:
-    repeat_kv(k, n_rep) ->
-    repeat_kv(v, n_rep) ->
-    sdpa(q, repeated_k, repeated_v)
-
-    This is replaced with torch.ops.auto_deploy.torch_attention_grouped_sdpa.
-    """
-    graph = gm.graph
-
-    # Track replacements to avoid processing nodes multiple times
-    num_grouped_patterns = 0
-
-    # Iterate through nodes in the graph
-    for node in list(graph.nodes):
-        # Look for SDPA nodes that could be part of our pattern
-        if is_op(node, torch.ops.auto_deploy.torch_attention_sdpa):
-            match_info = _match_grouped_attention_pattern(node)
-            if match_info:
-                ad_logger.debug(f"Found grouped attention pattern at {node}")
-                _replace_with_grouped_sdpa(graph, match_info)
-                num_grouped_patterns += 1
-
-    # Clean up the graph if we made any replacements
-    if num_grouped_patterns:
-        canonicalize_graph(gm)
-    ad_logger.info(f"Found {num_grouped_patterns} grouped attention patterns")
-
-
-def match_causal_attn_mask(gm: GraphModule) -> None:
-    """
-    Match attention operations with causal attention masks and optimize them.
-
-    For operations that use explicit causal masks, this replaces:
-    - sdpa(q, k, v, causal_mask, dropout_p, False, scale)
-    with:
-    - sdpa(q, k, v, None, dropout_p, True, scale)
-
-    This optimization enables more efficient implementations on supported backends.
-    """
-    graph = gm.graph
-
-    # Track replacements to avoid processing nodes multiple times
-    num_causal_patterns = 0
-
-    # Iterate through nodes in the graph
-    for node in list(graph.nodes):
-        # Look for SDPA nodes or grouped SDPA nodes
-        if not (
-            is_op(node, torch.ops.auto_deploy.torch_attention_sdpa)
-            or is_op(node, torch.ops.auto_deploy.torch_attention_grouped_sdpa)
-        ):
-            continue
-
-        # Get the attention mask argument (4th argument)
-        if len(node.args) < 4 or node.args[3] is None:
-            continue
-
-        attn_mask = node.args[3]
-
-        # Check if this mask is a causal mask
-        if not _is_causal_mask(attn_mask):
-            ad_logger.debug(f"Found non-causal attention mask at {node=}!")
-            continue
-
-        ad_logger.debug(f"Found causal attention mask at {node}")
-
-        # construct the new args list with args provided to the node and the default values otherwise
-        new_args = []
-        for idx, arg in enumerate(node.target._schema.arguments):
-            # In case arg is provided to the node, use it
-            if idx < len(node.args):
-                new_args.append(node.args[idx])
-            # In case arg is not provided to the node, use the default value
-            elif arg.has_default_value:
-                new_args.append(arg.default_value)
-            else:
-                raise ValueError(f"Missing required argument: {arg.name}")
-
-        # Create new arguments with None mask and is_causal=True
-        new_args[3] = None  # Set mask to None
-        new_args[5] = True  # Set is_causal to True
-
-        # Create new node with updated arguments
-        with graph.inserting_before(node):
-            new_node = graph.call_function(node.target, args=tuple(new_args), kwargs=node.kwargs)
-
-        # Preserve metadata
-        new_node.meta = node.meta.copy()
-
-        # Replace the old node with the new one
-        node.replace_all_uses_with(new_node)
-
-        num_causal_patterns += 1
-
-    # Clean up the graph if we made any replacements
-    if num_causal_patterns:
-        canonicalize_graph(gm)
-    ad_logger.info(f"Found {num_causal_patterns} causal mask attention patterns")
-
-
-def _match_repeat_kv_pattern(reshape_node: Node) -> Optional[Dict[str, Node]]:
-    """
-    Match the repeat_kv pattern starting from a reshape node.
-
-    The pattern is:
-    unsqueeze -> expand -> reshape -> [optional] contiguous
-
-    Returns a dictionary with information about the match or None if no match.
-    """
-    # Check that reshape_node is a reshape operation
-    if not is_op(reshape_node, torch.ops.aten.reshape):
-        return None
-
-    # The reshape should have expand as its first argument
-    if len(reshape_node.args) < 1:
-        return None
-
-    expand_node = reshape_node.args[0]
-    if not is_op(expand_node, torch.ops.aten.expand):
-        return None
-
-    # The expand should have unsqueeze as its first argument
-    if len(expand_node.args) < 1:
-        return None
-
-    unsqueeze_node = expand_node.args[0]
-    if not is_op(unsqueeze_node, torch.ops.aten.unsqueeze):
-        return None
-
-    # The unsqueeze should be inserting a dimension at position 2
-    if len(unsqueeze_node.args) < 2 or unsqueeze_node.args[1] != 2:
-        return None
-
-    # Get the input tensor to unsqueeze
-    if len(unsqueeze_node.args) < 1:
-        return None
-
-    input_tensor = unsqueeze_node.args[0]
-
-    # Check input dimensions - should be 4D (batch, num_key_value_heads, seq_len, head_dim)
-    input_val = input_tensor.meta.get("val", None)
-    if input_val is None or len(input_val.shape) != 4:
-        return None
-
-    # Extract batch size, num_kv_heads, seq_len, and head_dim from the input tensor shape
-    batch_size, num_kv_heads, seq_len, head_dim = input_val.shape
-
-    # Check reshape args
-    if len(reshape_node.args) < 2 or not isinstance(reshape_node.args[1], list):
-        return None
-
-    reshape_args = reshape_node.args[1]
-    if len(reshape_args) != 4:
-        return None
-
-    # Check expand args
-    if len(expand_node.args) < 2 or not isinstance(expand_node.args[1], list):
-        return None
-
-    expand_args = expand_node.args[1]
-    if len(expand_args) != 5:
-        return None
-
-    # Determine n_rep by comparing the output and input head dimensions
-    # In the expand args, we should have [batch, num_kv_heads, n_rep, seq_len, head_dim]
-    # In the reshape args, we should have [batch, num_heads, seq_len, head_dim]
-    # where num_heads = num_kv_heads * n_rep
-    _, _, n_rep, _, _ = expand_args
-    _, reshape_num_heads, _, _ = reshape_args
-
-    # Check that n_rep is an integer
-    if not isinstance(n_rep, int):
-        return None
-
-    # Check that num_heads = num_kv_heads * n_rep
-    # This may be a symbolic expression, so we need to compare with caution
-    reshape_out_val = reshape_node.meta.get("val", None)
-    if reshape_out_val is None or len(reshape_out_val.shape) != 4:
-        return None
-
-    # Ensure output shape is correct
-    out_batch, out_heads, out_seq, out_dim = reshape_out_val.shape
-
-    # Check that input batch and seq dimensions match output
-    if out_batch != batch_size or out_seq != seq_len or out_dim != head_dim:
-        return None
-
-    # Check if reshape is followed by a contiguous node
-    contiguous_node = None
-    users = list(reshape_node.users)
-
-    # Only consider contiguous if reshape has exactly one user
-    if len(users) == 1 and is_op(users[0], torch.ops.aten.contiguous):
-        contiguous_node = users[0]
-
-    result = {
-        "input_tensor": input_tensor,
-        "unsqueeze_node": unsqueeze_node,
-        "expand_node": expand_node,
-        "reshape_node": reshape_node,
-        "n_rep": n_rep,
-    }
-
-    if contiguous_node:
-        result["contiguous_node"] = contiguous_node
-
-    return result
-
-
-def _match_eager_attention_pattern(final_matmul_node: Node) -> Optional[Dict[str, Node]]:
-    """
-    Match the eager attention pattern starting from the final matmul node.
-
-    The pattern is:
-    transpose -> matmul -> mul/div -> (optional) add -> (optional) to -> softmax -> (optional) to -> dropout -> matmul
-
-    Returns a dictionary with information about the match or None if no match.
-    """
-    # Check that final_matmul_node is a matmul operation
-    if not is_op(final_matmul_node, torch.ops.aten.matmul):
-        return None
-
-    # Check we have two arguments
-    if len(final_matmul_node.args) < 2:
-        return None
-
-    # The first arg of final matmul should be dropout
-    dropout_node = final_matmul_node.args[0]
-    if not is_op(dropout_node, torch.ops.aten.dropout):
-        return None
-
-    # The second arg of final matmul is the value tensor (possibly repeated/transformed)
-    value = final_matmul_node.args[1]
-
-    # The dropout should have a to_dtype node (or directly softmax) as input
-    if len(dropout_node.args) < 1:
-        return None
-
-    # Allow optional to_dtype node after softmax
-    to_dtype_after_softmax = dropout_node.args[0]
-    if is_op(to_dtype_after_softmax, torch.ops.aten.to):
-        if len(to_dtype_after_softmax.args) < 1:
-            return None
-        softmax_node = to_dtype_after_softmax.args[0]
-    else:
-        softmax_node = to_dtype_after_softmax
-
-    # Now we should have a softmax node
-    if not is_op(softmax_node, torch.ops.aten.softmax):
-        return None
-
-    # The softmax should have dim=-1 (may be specified in different ways)
-    if len(softmax_node.args) < 2 or (
-        isinstance(softmax_node.args[1], int) and softmax_node.args[1] != -1
-    ):
-        # Check kwargs if not in args
-        if softmax_node.kwargs.get("dim", -1) != -1:
-            return None
-
-    # The softmax node's input can be:
-    # - direct from add/mul/div
-    # - or through a to_dtype node (like to_35 in the example)
-    if len(softmax_node.args) < 1:
-        return None
-
-    # Handle optional to_dtype node before softmax
-    prev_node = softmax_node.args[0]
-    if is_op(prev_node, torch.ops.aten.to):
-        if len(prev_node.args) < 1:
-            return None
-        prev_node = prev_node.args[0]
-
-    # Check for attention mask pattern (add node)
-    if is_op(prev_node, torch.ops.aten.add):
-        add_node = prev_node
-        attn_mask = add_node.args[1]  # Second arg is the mask
-
-        # The add should have a mul or div node as its first argument
-        if len(add_node.args) < 1:
-            return None
-
-        scaling_node = add_node.args[0]
-        if not (is_op(scaling_node, torch.ops.aten.mul) or is_op(scaling_node, torch.ops.aten.div)):
-            return None
-    elif is_op(prev_node, torch.ops.aten.mul) or is_op(prev_node, torch.ops.aten.div):
-        # No mask case - the softmax input is directly the mul or div node
-        scaling_node = prev_node
-        attn_mask = None
-    else:
-        return None
-
-    # Check the scaling operation and extract the scaling factor
-    is_division = is_op(scaling_node, torch.ops.aten.div)
-
-    # The mul/div node should have a matmul node as input
-    if len(scaling_node.args) < 2:
-        return None
-
-    # Extract the scaling factor, adjusting for division vs multiplication
-    scale = scaling_node.args[1]
-    # Allow for constant or tensor scale
-    if not isinstance(scale, (float, int, Node)):
-        return None
-
-    # For division, we need to invert the scaling factor if it's a constant
-    if is_division and isinstance(scale, (float, int)):
-        scale = 1.0 / scale
-
-    first_matmul_node = scaling_node.args[0]
-    if not is_op(first_matmul_node, torch.ops.aten.matmul):
-        return None
-
-    # The first matmul should have the query and key transpose as inputs
-    if len(first_matmul_node.args) < 2:
-        return None
-
-    query = first_matmul_node.args[0]
-    transpose_key = first_matmul_node.args[1]
-
-    # Check for transpose, could be any dimensions
-    if not is_op(transpose_key, torch.ops.aten.transpose):
-        return None
-
-    # The transpose should have the key as input
-    if len(transpose_key.args) < 1:
-        return None
-
-    key = transpose_key.args[0]
-
-    # Create the match info dictionary
-    match_info = {
-        "query": query,
-        "key": key,
-        "value": value,
-        "scale": scale,
-        "dropout_p": dropout_node.args[1] if len(dropout_node.args) > 1 else 0.0,
-        "final_matmul": final_matmul_node,
-    }
-
-    # Add the attention mask if it exists
-    if attn_mask is not None:
-        match_info["attn_mask"] = attn_mask
-
-    return match_info
-
-
-def _match_grouped_attention_pattern(sdpa_node: Node) -> Optional[Dict[str, Node]]:
-    """
-    Match the grouped attention pattern starting from an SDPA node.
-
-    The pattern is:
-    repeat_kv(k, n_rep) ->
-    repeat_kv(v, n_rep) ->
-    sdpa(q, repeated_k, repeated_v)
-
-    Returns a dictionary with information about the match or None if no match.
-    """
-    # Check that sdpa_node is an SDPA operation
-    if not is_op(sdpa_node, torch.ops.auto_deploy.torch_attention_sdpa):
-        return None
-
-    # SDPA should have query, key, value as its first three arguments
-    if len(sdpa_node.args) < 3:
-        return None
-
-    query, key_repeated, value_repeated = sdpa_node.args[0:3]
-
-    # Key and value should come from repeat_kv operations
-    if not is_op(key_repeated, torch.ops.auto_deploy.torch_attention_repeat_kv) or not is_op(
-        value_repeated, torch.ops.auto_deploy.torch_attention_repeat_kv
-    ):
-        return None
-
-    # Extract the original key, value, and n_rep
-    orig_key = key_repeated.args[0]
-    orig_value = value_repeated.args[0]
-    key_n_rep = key_repeated.args[1]
-    value_n_rep = value_repeated.args[1]
-
-    # Both repeat_kv operations should have the same n_rep
-    if key_n_rep != value_n_rep:
-        return None
-
-    # Return the match information
-    return {
-        "query": query,
-        "key": orig_key,
-        "value": orig_value,
-        "key_repeated": key_repeated,
-        "value_repeated": value_repeated,
-        "n_rep": key_n_rep,
-        "sdpa_node": sdpa_node,
-    }
-
-
-def _replace_with_repeat_kv(graph, match_info: Dict[str, Node]) -> None:
-    """
-    Replace the matched repeat_kv pattern with the custom op.
-    """
-    input_tensor = match_info["input_tensor"]
-    reshape_node = match_info["reshape_node"]
-    n_rep = match_info["n_rep"]
-
-    # Determine the node to replace (either reshape or contiguous if present)
-    node_to_replace = match_info.get("contiguous_node", reshape_node)
-
-    with graph.inserting_before(node_to_replace):
-        repeat_kv_node = graph.call_function(
-            torch.ops.auto_deploy.torch_attention_repeat_kv, args=(input_tensor, n_rep)
+    def register_repeat_kv(patterns: ADPatternMatcherPass):
+        dummy_args = [
+            torch.randn(8, 8, 16, 64, device="cuda", dtype=torch.float16),
+            7,
+        ]
+        register_ad_pattern(
+            search_fn=_repeat_kv_pattern,
+            replace_fn=_repeat_kv_repl,
+            patterns=patterns,
+            dummy_args=dummy_args,
+            op_ignore_types={
+                torch.ops.aten.reshape.default: (int,),
+                torch.ops.aten.expand.default: (int,),
+            },
+            scalar_workaround={"n_rep": dummy_args[1]},
         )
 
-    # Preserve metadata from the original node
-    repeat_kv_node.meta = node_to_replace.meta.copy()
+    def register_eager_attention(patterns: ADPatternMatcherPass):
+        for pattern_config in _get_sfdp_patterns():
+            register_ad_pattern(**pattern_config, patterns=patterns)
 
-    # Replace all uses of the node with the repeat_kv node
-    node_to_replace.replace_all_uses_with(repeat_kv_node)
+    def register_grouped_attention(patterns: ADPatternMatcherPass):
+        q = torch.randn(8, 8, 16, 64, device="cuda", dtype=torch.float16)
+        k1 = torch.randn(8, 1, 16, 64, device="cuda", dtype=torch.float16)
+        v1 = torch.randn(8, 1, 16, 64, device="cuda", dtype=torch.float16)
+        attn_mask = torch.randn(8, 1, 1, 16, device="cuda", dtype=torch.float16)
+        dropout = 0.12345
+        scale = 0.56789
+        n_rep = 7
 
+        dummy_args_1 = [q, k1, v1, n_rep, attn_mask, dropout, scale]
+        dummy_args_2 = [q, k1, v1, attn_mask, dropout, scale]
 
-def _replace_with_sdpa(graph, match_info: Dict[str, Node]) -> None:
-    """
-    Replace the matched eager attention pattern with scaled_dot_product_attention.
-    """
-    # retrieve the default op for scaled_dot_product_attention
-    sdpa_op = torch.ops.auto_deploy.torch_attention_sdpa.default
-
-    # construct the args for the ops based on the match_info and the op's schema
-    args = []
-    for arg in sdpa_op._schema.arguments:
-        if arg.name in match_info:
-            args.append(match_info[arg.name])
-        elif arg.has_default_value:
-            args.append(arg.default_value)
-        else:
-            raise ValueError(f"Missing required argument: {arg.name}")
-    args = tuple(args)
-
-    # retrieve the final matmul node to know where to insert the sdpa node
-    final_matmul = match_info["final_matmul"]
-
-    with graph.inserting_before(final_matmul):
-        sdpa_node = graph.call_function(sdpa_op, args=args)
-
-    # Preserve metadata from the original node
-    sdpa_node.meta = final_matmul.meta.copy()
-
-    # Replace all uses of the final matmul node with the sdpa node
-    final_matmul.replace_all_uses_with(sdpa_node)
-
-
-def _replace_with_grouped_sdpa(graph, match_info: Dict[str, Node]) -> None:
-    """
-    Replace the matched grouped attention pattern with torch.ops.auto_deploy.torch_attention_grouped_sdpa.
-    """
-    sdpa_node = match_info["sdpa_node"]
-    query = match_info["query"]
-    key = match_info["key"]
-    value = match_info["value"]
-
-    # Construct the new args and kwargs
-    args = (query, key, value) + sdpa_node.args[3:]
-    kwargs = sdpa_node.kwargs.copy()
-
-    with graph.inserting_before(sdpa_node):
-        grouped_sdpa_node = graph.call_function(
-            torch.ops.auto_deploy.torch_attention_grouped_sdpa.default, args=args, kwargs=kwargs
+        register_ad_pattern(
+            search_fn=_grouped_attn_pattern,
+            replace_fn=_grouped_attn_replacement,
+            patterns=patterns,
+            dummy_args=dummy_args_1,
+            scalar_workaround={"scale": scale, "dropout_p": dropout, "n_rep": n_rep},
+        )
+        register_ad_pattern(
+            search_fn=_grouped_attn_pattern_2,
+            replace_fn=_grouped_attn_replacement_2,
+            patterns=patterns,
+            dummy_args=dummy_args_2,
+            scalar_workaround={
+                "scale": scale,
+                "dropout_p": dropout,
+            },
         )
 
-    # Preserve metadata from the original node
-    grouped_sdpa_node.meta = sdpa_node.meta.copy()
-
-    # Replace all uses of the SDPA node with the grouped_sdpa node
-    sdpa_node.replace_all_uses_with(grouped_sdpa_node)
+    _apply_pattern(gm, "Repeat KV", register_repeat_kv, shape_prop=True)
+    _apply_pattern(gm, "Eager Attention", register_eager_attention)
+    _apply_pattern(gm, "Grouped Attention", register_grouped_attention)
 
 
-def _is_causal_mask(mask_node: Node) -> bool:
-    """
-    Determine if a node represents a causal attention mask.
-
-    Causal masks typically involve:
-    1. Creating a matrix with very negative values (e.g., -inf or close to it)
-    2. Using triu with offset 1 to create an upper triangular matrix
-    3. Usually involves comparison operations (gt, lt) with position indices
-
-    Returns True if the node appears to be a causal mask pattern.
-    """
-    # Direct pattern from the test case: masked_fill with triu(ones,1) and -inf
-    if is_op(mask_node, torch.ops.aten.masked_fill):
-        mask_args = mask_node.args
-        if len(mask_args) >= 2:
-            _ = mask_args[0]  # zero tensor
-            mask_tensor = mask_args[1]
-            fill_value = mask_args[2] if len(mask_args) > 2 else mask_node.kwargs.get("value", None)
-
-            # Check if fill value is very negative (e.g., -inf)
-            if fill_value is not None and (
-                fill_value == float("-inf")
-                or (isinstance(fill_value, (int, float)) and fill_value < -1e4)
-            ):
-                # Try to trace back to find a triu pattern
-                if _has_triu_ancestor(mask_tensor, offset=1):
-                    return True
-
-    # Pattern from negative_fill test case: masked_fill with ~triu(ones,1) and 0.0
-    # The negative_fill pattern has a pre-filled tensor with very negative values
-    # and zeros in the lower triangle
-    if is_op(mask_node, torch.ops.aten.masked_fill):
-        mask_args = mask_node.args
-        if len(mask_args) >= 2:
-            negative_tensor = mask_args[0]
-            mask_tensor = mask_args[1]
-            fill_value = mask_args[2] if len(mask_args) > 2 else mask_node.kwargs.get("value", None)
-
-            # Check if fill value is zero and the tensor is pre-filled with negative values
-            if fill_value == 0.0 or fill_value == 0:
-                # Check for the full tensor with negative values
-                if is_op(negative_tensor, torch.ops.aten.full):
-                    fill_args = negative_tensor.args
-                    if (
-                        len(fill_args) > 1
-                        and isinstance(fill_args[1], (int, float))
-                        and fill_args[1] < -1e4
-                    ):
-                        # This is likely a negative-filled tensor
-                        # Now check if the mask is a bitwise_not of triu
-                        if is_op(mask_tensor, torch.ops.aten.bitwise_not):
-                            if len(mask_tensor.args) > 0 and _has_triu_ancestor(
-                                mask_tensor.args[0], offset=1
-                            ):
-                                return True
-
-    # Pattern for llama-3.1 style causal mask: slice of expand(unsqueeze(unsqueeze(mul_(triu, gt))))
-    if is_op(mask_node, torch.ops.aten.slice):
-        # Follow the chain backward to the source of the slice
-        if len(mask_node.args) == 0:
-            return False
-        slice_source = mask_node.args[0]
-
-        # Check for typical expand pattern
-        if not (slice_source and is_op(slice_source, torch.ops.aten.expand)):
-            return False
-
-        # Continue tracing back through the pattern
-        if len(slice_source.args) == 0:
-            return False
-        expand_source = slice_source.args[0]
-
-        # Check for first unsqueeze operation
-        if not (expand_source and is_op(expand_source, torch.ops.aten.unsqueeze)):
-            return False
-
-        # Look for the source of first unsqueeze
-        if len(expand_source.args) == 0:
-            return False
-        first_unsqueeze_source = expand_source.args[0]
-
-        # Check for second unsqueeze operation
-        if not (first_unsqueeze_source and is_op(first_unsqueeze_source, torch.ops.aten.unsqueeze)):
-            return False
-
-        # Look for the source of the second unsqueeze
-        if len(first_unsqueeze_source.args) == 0:
-            return False
-        second_unsqueeze_source = first_unsqueeze_source.args[0]
-
-        # Check for mul_ operation
-        if is_op(second_unsqueeze_source, torch.ops.aten.mul_):
-            # Check if one of the mul_ arguments is a triu operation
-            has_triu = False
-            for arg in second_unsqueeze_source.args:
-                if is_op(arg, torch.ops.aten.triu):
-                    if len(arg.args) > 1 and arg.args[1] == 1:
-                        has_triu = True
-                        break
-
-            if has_triu:
-                # Check if one of the mul_ arguments involves a full tensor with negative values
-                for arg in second_unsqueeze_source.args:
-                    if is_op(arg, torch.ops.aten.full):
-                        if (
-                            len(arg.args) > 1
-                            and isinstance(arg.args[1], (int, float))
-                            and arg.args[1] < -1e4
-                        ):
-                            return True
-
-            return has_triu
-
-    # Original implementation for backward compatibility
-    if is_op(mask_node, torch.ops.aten.slice):
-        # Follow the chain backward to the source of the slice
-        if len(mask_node.args) == 0:
-            return False
-        slice_source = mask_node.args[0]
-
-        # Check for typical expand pattern
-        if not (slice_source and is_op(slice_source, torch.ops.aten.expand)):
-            return False
-
-        # Continue tracing back through the pattern
-        if len(slice_source.args) == 0:
-            return False
-        expand_source = slice_source.args[0]
-
-        # Check for unsqueeze operations
-        if not (expand_source and is_op(expand_source, torch.ops.aten.unsqueeze)):
-            return False
-
-        # Look for the source of the unsqueeze
-        if len(expand_source.args) == 0:
-            return False
-        unsqueeze_source = expand_source.args[0]
-
-        if not unsqueeze_source:
-            return False
-
-        # Check for triu pattern which is common in causal masks
-        if is_op(unsqueeze_source, torch.ops.aten.mul_):
-            for arg in unsqueeze_source.args:
-                if not is_op(arg, torch.ops.aten.triu):
-                    continue
-
-                if len(arg.args) <= 1:
-                    continue
-
-                triu_offset = arg.args[1]
-                # Causal masks typically use triu with offset 1
-                if triu_offset == 1:
-                    return True
-
-            return False
-
-        # Check if we have a full tensor filled with a very negative number
-        if not is_op(unsqueeze_source, torch.ops.aten.full):
-            return False
-
-        if len(unsqueeze_source.args) <= 1:
-            return False
-
-        fill_value = unsqueeze_source.args[1]
-        # Check if the fill value is very negative (likely -inf or close)
-        if isinstance(fill_value, float) and fill_value < -1e10:
-            return True
-
-    # If we can't definitively identify it as causal, return False
-    return False
+def _repeat_kv_pattern(hidden_states, n_rep) -> torch.Tensor:
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = torch.unsqueeze(hidden_states, 2)
+    hidden_states = hidden_states.expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
-def _has_triu_ancestor(node: Node, offset: int = 1, depth: int = 0, max_depth: int = 5) -> bool:
-    """Helper function to find a triu operation in the ancestry of a node."""
-    if depth > max_depth:  # Prevent infinite recursion
-        return False
+def _repeat_kv_repl(hidden_states, n_rep) -> torch.Tensor:
+    return torch.ops.auto_deploy.torch_attention_repeat_kv(hidden_states, n_rep)
 
-    if is_op(node, torch.ops.aten.triu):
-        if len(node.args) > 1 and node.args[1] == offset:
-            return True
 
-    # Check if any of the arguments has a triu ancestor
-    for arg in node.args:
-        if isinstance(arg, Node) and _has_triu_ancestor(arg, offset, depth + 1, max_depth):
-            return True
+# with causal_mask, no division
+def _sfdp_pattern_1(query, key, value, attention_mask, scaling, dropout):
+    attn_weights = torch.matmul(query, key.transpose(2, 3)) * scaling
+    attn_weights = attn_weights + attention_mask
+    attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_weights = F.dropout(attn_weights, p=dropout, training=False)
+    attn_output = torch.matmul(attn_weights, value)
+    return attn_output
 
-    # Check if any of the kwargs has a triu ancestor
-    for value in node.kwargs.values():
-        if isinstance(value, Node) and _has_triu_ancestor(value, offset, depth + 1, max_depth):
-            return True
 
-    return False
+def _sfdp_replacement_1(query, key, value, attention_mask, scaling, dropout):
+    return torch.ops.auto_deploy.torch_attention_sdpa.default(
+        query,
+        key,
+        value,
+        attn_mask=attention_mask,
+        dropout_p=dropout,
+        is_causal=False,
+        scale=scaling,
+    )
+
+
+# no causal_mask, no division
+def _sfdp_pattern_2(query, key, value, scaling, dropout):
+    attn_weights = torch.matmul(query, key.transpose(2, 3)) * scaling
+    attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_weights = F.dropout(attn_weights, p=dropout, training=False)
+    attn_output = torch.matmul(attn_weights, value)
+    return attn_output
+
+
+def _sfdp_replacement_2(query, key, value, scaling, dropout):
+    return torch.ops.auto_deploy.torch_attention_sdpa.default(
+        query,
+        key,
+        value,
+        attn_mask=None,
+        dropout_p=dropout,
+        is_causal=False,
+        scale=scaling,
+    )
+
+
+# with causal_mask, with division
+def _sfdp_pattern_3(query, key, value, attention_mask, scaling, dropout):
+    attn_weights = torch.matmul(query, key.transpose(2, 3)) / scaling
+    attn_weights = attn_weights + attention_mask
+    attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_weights = F.dropout(attn_weights, p=dropout, training=False)
+    attn_output = torch.matmul(attn_weights, value)
+    return attn_output
+
+
+def _sfdp_replacement_3(query, key, value, attention_mask, scaling, dropout):
+    scaling = 1.0 / scaling
+    return torch.ops.auto_deploy.torch_attention_sdpa.default(
+        query,
+        key,
+        value,
+        attn_mask=attention_mask,
+        dropout_p=dropout,
+        is_causal=False,
+        scale=scaling,
+    )
+
+
+# no causal_mask, with division
+def _sfdp_pattern_4(query, key, value, scaling, dropout):
+    attn_weights = torch.matmul(query, key.transpose(2, 3)) / scaling
+    attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_weights = F.dropout(attn_weights, p=dropout, training=False)
+    attn_output = torch.matmul(attn_weights, value)
+    return attn_output
+
+
+def _sfdp_replacement_4(query, key, value, scaling, dropout):
+    scaling = 1.0 / scaling
+    return torch.ops.auto_deploy.torch_attention_sdpa.default(
+        query,
+        key,
+        value,
+        attn_mask=None,
+        dropout_p=dropout,
+        is_causal=False,
+        scale=scaling,
+    )
+
+
+# no causal_mask, with division, explicit casting model
+def _sfdp_pattern_5(query, key, value, scaling, dropout):
+    attn_weights = torch.matmul(query, key.transpose(2, 3)) / scaling
+    attn_weights = attn_weights.to(torch.float32)
+    attn_weights = F.softmax(attn_weights, dim=-1).to(query.dtype)
+    attn_weights = F.dropout(attn_weights, p=dropout, training=False)
+    attn_output = torch.matmul(attn_weights, value)
+    return attn_output
+
+
+def _sfdp_replacement_5(query, key, value, scaling, dropout):
+    scaling = 1.0 / scaling
+    return torch.ops.auto_deploy.torch_attention_sdpa.default(
+        query,
+        key,
+        value,
+        attn_mask=None,
+        dropout_p=dropout,
+        is_causal=False,
+        scale=scaling,
+    )
+
+
+# with causal_mask, with division, explicit casting model
+def _sfdp_pattern_6(query, key, value, attention_mask, scaling, dropout):
+    attn_weights = torch.matmul(query, key.transpose(2, 3)) / scaling
+    attn_weights = attn_weights + attention_mask
+    attn_weights = attn_weights.to(torch.float32)
+    attn_weights = F.softmax(attn_weights, dim=-1).to(query.dtype)
+    attn_weights = F.dropout(attn_weights, p=dropout, training=False)
+    attn_output = torch.matmul(attn_weights, value)
+    return attn_output
+
+
+def _sfdp_replacement_6(query, key, value, attention_mask, scaling, dropout):
+    scaling = 1.0 / scaling
+    return torch.ops.auto_deploy.torch_attention_sdpa.default(
+        query,
+        key,
+        value,
+        attn_mask=attention_mask,
+        dropout_p=dropout,
+        is_causal=False,
+        scale=scaling,
+    )
+
+
+def _get_sfdp_patterns() -> List[Dict[str, Any]]:
+    bs, seq_len, n_heads, hidden_size = 8, 16, 8, 512
+    head_dim = hidden_size // n_heads
+
+    def common_tensor():
+        return torch.randn(bs, n_heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16)
+
+    def causal_mask():
+        return torch.randn(bs, 1, 1, seq_len, device="cuda", dtype=torch.bfloat16)
+
+    configs = [
+        (_sfdp_pattern_1, _sfdp_replacement_1, True, 0.1234743, 0.85849734),
+        (_sfdp_pattern_2, _sfdp_replacement_2, False, 0.234743, 0.5849734),
+        (_sfdp_pattern_3, _sfdp_replacement_3, True, 0.34743, 0.849734),
+        (_sfdp_pattern_4, _sfdp_replacement_4, False, 0.74321, 0.9734),
+        (_sfdp_pattern_5, _sfdp_replacement_5, False, 0.874321, 0.89734),
+        (_sfdp_pattern_6, _sfdp_replacement_6, True, 0.634743, 0.6849734),
+    ]
+
+    patterns = []
+    for search_fn, replace_fn, has_mask, scale, dropout in configs:
+        dummy_args = [common_tensor(), common_tensor(), common_tensor()]
+        if has_mask:
+            dummy_args.append(causal_mask())
+        dummy_args.extend([scale, dropout])
+
+        patterns.append(
+            {
+                "search_fn": search_fn,
+                "replace_fn": replace_fn,
+                "dummy_args": dummy_args,
+                "scalar_workaround": {"scaling": scale, "dropout": dropout},
+                "op_ignore_types": {torch.ops.aten.to.dtype: (torch.dtype,)},
+            }
+        )
+
+    return patterns
+
+
+def _grouped_attn_pattern(q, k, v, n_rep, attn_mask, dropout_p, scale):
+    k = torch.ops.auto_deploy.torch_attention_repeat_kv(k, n_rep)
+    v = torch.ops.auto_deploy.torch_attention_repeat_kv(v, n_rep)
+    return torch.ops.auto_deploy.torch_attention_sdpa.default(
+        q, k, v, attn_mask=attn_mask, dropout_p=dropout_p, is_causal=False, scale=scale
+    )
+
+
+def _grouped_attn_replacement(q, k, v, n_rep, attn_mask, dropout_p, scale):
+    return torch.ops.auto_deploy.torch_attention_grouped_sdpa.default(
+        q, k, v, attn_mask=attn_mask, dropout_p=dropout_p, is_causal=False, scale=scale
+    )
+
+
+# Only expose torch_attention_grouped_sdpa after the transformation
+def _grouped_attn_pattern_2(q, k, v, attn_mask, dropout_p, scale):
+    return torch.ops.auto_deploy.torch_attention_sdpa.default(
+        q, k, v, attn_mask=attn_mask, dropout_p=dropout_p, is_causal=False, scale=scale
+    )
+
+
+def _grouped_attn_replacement_2(q, k, v, attn_mask, dropout_p, scale):
+    return torch.ops.auto_deploy.torch_attention_grouped_sdpa.default(
+        q, k, v, attn_mask=attn_mask, dropout_p=dropout_p, is_causal=False, scale=scale
+    )
 
 
 def match_attention_layout(gm: GraphModule, attention_op: Type[AttentionDescriptor]) -> None:

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -25,11 +25,8 @@ from .library import (
     fuse_rmsnorm,
     insert_cached_attention,
     match_attention_layout,
-    match_causal_attn_mask,
-    match_eager_attention,
-    match_grouped_attention,
+    match_attention_pattern,
     match_moe_pattern,
-    match_repeat_kv,
     match_rope_layout,
     match_rope_pattern,
     optimize_rope,
@@ -78,17 +75,8 @@ class InferenceOptimizer:
         # Match MoE pattern
         match_moe_pattern(egm)
 
-        # Match repeat_kv pattern
-        match_repeat_kv(egm)
-
-        # Match eager attention pattern
-        match_eager_attention(egm)
-
-        # Match grouped attention pattern
-        match_grouped_attention(egm)
-
-        # Match and optimize causal attention masks
-        match_causal_attn_mask(egm)
+        # Match attention pattern
+        match_attention_pattern(egm)
 
         # Match attention layout expected by our backend
         match_attention_layout(egm, AttentionRegistry.get(self.ad_config.attn_backend))

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -25,8 +25,10 @@ from .library import (
     fuse_rmsnorm,
     insert_cached_attention,
     match_attention_layout,
-    match_attention_pattern,
+    match_eager_attention,
+    match_grouped_attention,
     match_moe_pattern,
+    match_repeat_kv,
     match_rope_layout,
     match_rope_pattern,
     optimize_rope,
@@ -75,8 +77,14 @@ class InferenceOptimizer:
         # Match MoE pattern
         match_moe_pattern(egm)
 
-        # Match attention pattern
-        match_attention_pattern(egm)
+        # Match repeat_kv pattern
+        match_repeat_kv(egm)
+
+        # Match eager attention pattern
+        match_eager_attention(egm)
+
+        # Match grouped attention pattern
+        match_grouped_attention(egm)
 
         # Match attention layout expected by our backend
         match_attention_layout(egm, AttentionRegistry.get(self.ad_config.attn_backend))

--- a/tensorrt_llm/_torch/auto_deploy/utils/pattern_matcher.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/pattern_matcher.py
@@ -153,6 +153,8 @@ def register_ad_pattern(
     5. register_replacement can auto-generate `search_fn_pattern` if you input `example_inputs`,
         but that approach will fail when symbolic shapes are involved. Here
         we explicitly trace & convert via `fx_to_pattern`.
+    6. The PatternMatcherPass would check num_users of the nodes, meaning that the pattern is required
+        to be functionally isolated, no intermediate nodes are shared with the rest of the graph.
 
     """
     argnames = list(inspect.signature(search_fn).parameters.keys())

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
@@ -16,7 +16,9 @@ from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transformations._graph import move_to_device
 from tensorrt_llm._torch.auto_deploy.transformations.library import (
     match_attention_layout,
-    match_attention_pattern,
+    match_eager_attention,
+    match_grouped_attention,
+    match_repeat_kv,
 )
 
 torch.manual_seed(0)
@@ -47,7 +49,9 @@ class HFWrapper(nn.Module):
 
 
 def _joint_transform(gm: GraphModule) -> None:
-    match_attention_pattern(gm)
+    match_repeat_kv(gm)
+    match_eager_attention(gm)
+    match_grouped_attention(gm)
     match_attention_layout(gm, MockAttentionDescriptor())
 
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
@@ -1,23 +1,25 @@
 """Test that the attention matcher works with HF's SDPA backends."""
 
+import copy
 from typing import Any, Callable, Dict
 
 import pytest
 import torch
 import torch.nn as nn
-from _graph_test_helpers import run_test
+from accelerate import init_empty_weights
 from torch.export import Dim
 from torch.fx import GraphModule
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaModel
 
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.transformations._graph import move_to_device
 from tensorrt_llm._torch.auto_deploy.transformations.library import (
     match_attention_layout,
-    match_causal_attn_mask,
-    match_eager_attention,
-    match_grouped_attention,
-    match_repeat_kv,
+    match_attention_pattern,
 )
+
+torch.manual_seed(0)
 
 
 class MockAttentionDescriptor:
@@ -45,10 +47,7 @@ class HFWrapper(nn.Module):
 
 
 def _joint_transform(gm: GraphModule) -> None:
-    match_repeat_kv(gm)
-    match_eager_attention(gm)
-    match_grouped_attention(gm)
-    match_causal_attn_mask(gm)
+    match_attention_pattern(gm)
     match_attention_layout(gm, MockAttentionDescriptor())
 
 
@@ -65,23 +64,6 @@ def _joint_transform(gm: GraphModule) -> None:
     ["eager", "sdpa"],
 )
 def test_match_llama_attention(config: Dict[str, Any], attn_implementation: str):
-    batch_size, seq_len = 4, 12
-    full_config = {
-        "num_hidden_layers": 1,
-        "vocab_size": 256,
-        "hidden_size": 128,
-        "intermediate_size": 128,
-        "attn_implementation": attn_implementation,
-        **config,
-    }
-    dynamic_shapes = {0: Dim("batch_size", max=8), 1: Dim("seq_len", min=4, max=16)}
-
-    model = HFWrapper(LlamaModel(LlamaConfig(**full_config))).to("cuda")
-    model.eval()
-    x = torch.randint(
-        0, full_config["vocab_size"], (batch_size, seq_len), dtype=torch.long, device="cuda"
-    )
-
     def verify_matcher(gm: GraphModule):
         """Ensure that there is exactly one torch.ops.auto_deploy.torch_attention_bsnd_grouped_sdpa
         call in the graph. Also check that there is no repeat_kv pattern left.
@@ -106,18 +88,69 @@ def test_match_llama_attention(config: Dict[str, Any], attn_implementation: str)
             op="call_function", target=torch.ops.auto_deploy.torch_attention_repeat_kv
         )
         assert len(nodes) == 0, "Found repeat_kv pattern in the graph"
+        attn_nodes = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.auto_deploy.torch_attention_sdpa
+        )
+        assert len(attn_nodes) == 0, "Found torch_attention_sdpa node in the graph"
 
         return True
 
-    _ = run_test(
-        model,
-        x,
-        _joint_transform,
-        verify_matcher,
-        lambda num_p_og: num_p_og,
-        atol=1e-3,
-        rtol=5e-2,
-        test_load_hook=True,
-        strict_loading=True,
-        dynamic_shapes=dynamic_shapes,
+    batch_size, seq_len = 2, 4
+    full_config = {
+        "num_hidden_layers": 1,
+        "vocab_size": 256,
+        "hidden_size": 128,
+        "intermediate_size": 128,
+        "attn_implementation": attn_implementation,
+        **config,
+    }
+    dynamic_shapes = {0: Dim("batch_size", max=8), 1: Dim("seq_len", min=2, max=8)}
+
+    # Build and export model on meta device
+    with init_empty_weights():
+        model = HFWrapper(LlamaModel(LlamaConfig(**full_config))).eval()
+    x = torch.randint(
+        0, full_config["vocab_size"], (batch_size, seq_len), dtype=torch.long, device="cuda"
     )
+    gm = torch_export_to_gm(model, args=(x,), dynamic_shapes=(dynamic_shapes,), clone=True)
+
+    print("Exported gm", gm)
+    gm_exported = copy.deepcopy(gm)
+
+    # Move model to cuda
+    device = "cuda"
+    model._apply(
+        lambda t: torch.normal(0.0, 1.0, size=t.shape, device=device).to(t.dtype)
+        if t.device == torch.device("meta")
+        else t.to(device)
+    )
+    y_model = model(x)
+
+    gm_exported._apply(
+        lambda t: torch.normal(0.0, 1.0, size=t.shape, device=device).to(t.dtype)
+        if t.device == torch.device("meta")
+        else t.to(device)
+    )
+    gm_exported.load_state_dict(model.state_dict())
+    move_to_device(gm_exported, "cuda")
+    y_gm_exported = gm_exported(x)
+    torch.testing.assert_close(y_gm_exported, y_model, atol=5e-3, rtol=5e-3)
+
+    # Apply transformation
+    _joint_transform(gm)
+    assert verify_matcher(gm)
+    print("Transformed gm", gm)
+
+    # Move gm to cuda
+    gm._apply(
+        lambda t: torch.normal(0.0, 1.0, size=t.shape, device=device).to(t.dtype)
+        if t.device == torch.device("meta")
+        else t.to(device)
+    )
+    gm.load_state_dict(model.state_dict())
+    move_to_device(gm, "cuda")
+
+    # Verify output
+    y_gm = gm(x)
+    torch.testing.assert_close(y_gm_exported, y_gm, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(y_model, y_gm, atol=5e-2, rtol=5e-2)


### PR DESCRIPTION
## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

Perf comparison:
**TP=1**

**Before:**
```
Request Throughput (req/sec):                     21.8243
Total Output Throughput (tokens/sec):             2793.5093
Total Token Throughput (tokens/sec):              5587.0186
Total Latency (ms):                               45820.5022
Average request latency (ms):                     35422.4192
Per User Output Throughput [w/ ctx] (tps/user):   3.9171
Per GPU Output Throughput (tps/gpu):              2793.5093

-- Request Latency Breakdown (ms) -----------------------

[Latency] P50    : 33081.3765
[Latency] P90    : 45524.0860
[Latency] P95    : 45632.3470
[Latency] P99    : 45701.6415
[Latency] MINIMUM: 20661.4764
[Latency] MAXIMUM: 45723.5925
[Latency] AVERAGE: 35422.4192
```

**After:**
```
Request Throughput (req/sec):                     21.7760
Total Output Throughput (tokens/sec):             2787.3277
Total Token Throughput (tokens/sec):              5574.6554
Total Latency (ms):                               45922.1207
Average request latency (ms):                     35510.7135
Per User Output Throughput [w/ ctx] (tps/user):   3.9077
Per GPU Output Throughput (tps/gpu):              2787.3277

-- Request Latency Breakdown (ms) -----------------------

[Latency] P50    : 33174.8827
[Latency] P90    : 45642.2306
[Latency] P95    : 45751.7014
[Latency] P99    : 45823.0723
[Latency] MINIMUM: 20707.4193
[Latency] MAXIMUM: 45844.0460
[Latency] AVERAGE: 35510.7135

```

**Torch backend**
```
Request Throughput (req/sec):                     23.9185
Total Output Throughput (tokens/sec):             3061.5633
Total Token Throughput (tokens/sec):              6123.1266
Total Latency (ms):                               41808.7059
Average request latency (ms):                     32041.4108
Per User Output Throughput [w/ ctx] (tps/user):   4.3437
Per GPU Output Throughput (tps/gpu):              3061.5633

-- Request Latency Breakdown (ms) -----------------------

[Latency] P50    : 29452.0165
[Latency] P90    : 41541.7157
[Latency] P95    : 41646.4502
[Latency] P99    : 41711.8171
[Latency] MINIMUM: 18656.0955
[Latency] MAXIMUM: 41730.9255
[Latency] AVERAGE: 32041.4108
```

**TP=2**

**Before:**
current tip of `feat/ad-2025-07-22`: a83a455985b1d3eacff3fe3682f5ae432e0faf9f
```
Request Throughput (req/sec):                     33.0180
Total Output Throughput (tokens/sec):             4226.3013
Total Token Throughput (tokens/sec):              8452.6025
Total Latency (ms):                               30286.5300
Average request latency (ms):                     23706.4401
Per User Output Throughput [w/ ctx] (tps/user):   5.8266
Per GPU Output Throughput (tps/gpu):              2113.1506

-- Request Latency Breakdown (ms) -----------------------

[Latency] P50    : 21067.0984
[Latency] P90    : 30156.4320
[Latency] P95    : 30194.0892
[Latency] P99    : 30210.4725
[Latency] MINIMUM: 14916.3822
[Latency] MAXIMUM: 30211.2936
[Latency] AVERAGE: 23706.4401
```

**After:**
```
Request Throughput (req/sec):                     38.0126
Total Output Throughput (tokens/sec):             4865.6092
Total Token Throughput (tokens/sec):              9731.2185
Total Latency (ms):                               26307.0859
Average request latency (ms):                     20630.8526
Per User Output Throughput [w/ ctx] (tps/user):   6.6886
Per GPU Output Throughput (tps/gpu):              2432.8046

-- Request Latency Breakdown (ms) -----------------------

[Latency] P50    : 18512.5907
[Latency] P90    : 26174.1575
[Latency] P95    : 26203.5425
[Latency] P99    : 26216.7312
[Latency] MINIMUM: 12949.8892
[Latency] MAXIMUM: 26217.8347
[Latency] AVERAGE: 20630.8526

```

**Torch backend**
```
Request Throughput (req/sec):                     42.7781
Total Output Throughput (tokens/sec):             5475.5997
Total Token Throughput (tokens/sec):              10951.1994
Total Latency (ms):                               23376.4350
Average request latency (ms):                     18153.3846
Per User Output Throughput [w/ ctx] (tps/user):   7.6369
Per GPU Output Throughput (tps/gpu):              2737.7998

-- Request Latency Breakdown (ms) -----------------------

[Latency] P50    : 16003.2420
[Latency] P90    : 23247.0214
[Latency] P95    : 23275.8121
[Latency] P99    : 23288.1570
[Latency] MINIMUM: 11340.0914
[Latency] MAXIMUM: 23289.1028
[Latency] AVERAGE: 18153.3846
```

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
