### PR TITLE
Move KV cache transforms to new inf optimizer

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -1,0 +1,256 @@
+"""Graph transformation to automatically add kv cache into fused MHA op."""
+
+import operator
+from typing import Dict, Tuple, Type
+
+import torch
+from pydantic import ConfigDict, Field
+from torch.fx import Graph, GraphModule, Node
+
+from ...custom_ops.attention_interface import AttentionDescriptor, CacheConfig
+from ...distributed.common import all_gather_object, get_world_size
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface
+from ...transformations._graph import add_graph_input
+from ...utils.logger import ad_logger
+from ...utils.node_utils import get_all_input_output_nodes, is_op
+from ..interface import BaseTransform, TransformConfig, TransformInfo, TransformRegistry
+
+
+@TransformRegistry.register("update_in_out_nodes")
+class UpdateInOutNodes(BaseTransform):
+    """Modify the graph module by adding new input nodes and canonicalizing the graph.
+
+    The new input nodes correspond to the extra arguments needed for cached and flattened attention.
+
+    Args:
+        egm: The graph module to analyze and modify.
+        cm: Cached sequence interface containing extra argument information.
+    """
+
+    def _apply(
+        self, gm: GraphModule, cm: CachedSequenceInterface, factory: ModelFactory
+    ) -> Tuple[GraphModule, TransformInfo]:
+        # loop through nodes to get input, output, and get_attr nodes
+        input_nodes, output_nodes = get_all_input_output_nodes(gm.graph)
+
+        # we only expect one input node
+        assert len(input_nodes) == 2, "Expected exactly two input nodes (input_ids, position_ids)."
+
+        # NOTE: for now, we wanna make sure we *only* return the final output and no hidden states.
+        # Later on, we can revisit how to support returning hidden states.
+        assert len(output_nodes) == 1, "Expected exactly one output node!"
+        assert len(output_nodes[0].all_input_nodes) == 1, (
+            "Expected to only return final tensor output!"
+        )
+
+        # Activate and add extra argument nodes
+        new_args = cm.info.switch_to_cached_attn_inputs()
+        for name in new_args:
+            input_nodes.append(add_graph_input(gm, name))
+
+        # TODO:(hg) confirm this
+        info = TransformInfo(skipped=False, num_matches=1, is_clean=True, has_valid_shapes=True)
+
+        return gm, info
+
+
+class InsertCachedAttentionConfig(TransformConfig):
+    """Configuration for the insert cached attention transform."""
+
+    # NOTE:type CacheConfig contains a torch.dtype not supported by pydantic. We set this to avoid error.
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    attn_descriptor: Type[AttentionDescriptor] = Field(
+        description="The attention descriptor to use."
+    )
+    cache_config: CacheConfig = Field(description="The cache config to use.")
+
+
+@TransformRegistry.register("insert_cached_attention")
+class InsertCachedAttention(BaseTransform):
+    """A transform to insert cached attention into the graph module."""
+
+    config: InsertCachedAttentionConfig
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return InsertCachedAttentionConfig
+
+    def _apply(
+        self, gm: GraphModule, cm: CachedSequenceInterface, factory: ModelFactory
+    ) -> Tuple[GraphModule, TransformInfo]:
+        """Replace uncached source attention node with corresponding cached attn node."""
+        attn_descriptor = self.config.attn_descriptor
+        cache_config = self.config.cache_config
+
+        # Get all attention nodes and their info objects
+        source_op = attn_descriptor.get_source_attention_op()
+
+        # pick up graph
+        graph: Graph = gm.graph
+
+        # look for relevant source attention nodes
+        source_attn_nodes = [n for n in graph.nodes if is_op(n, source_op)]
+
+        if not source_attn_nodes:
+            # If there are no nodes for kv cache insertion found, return current graph
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+
+        # Sanity check
+        if cm.info.is_paged:
+            assert attn_descriptor.is_paged(), "Paged sequence info requires paged attention op."
+
+        # retrieve input nodes
+        input_nodes, _ = get_all_input_output_nodes(gm.graph)
+
+        # insert metadata computation and extract each argument as a node
+        get_metadata, num_metadata = attn_descriptor.get_prepare_metadata_op()
+        with graph.inserting_before(input_nodes[-1].next):
+            ret_node = graph.call_function(
+                get_metadata,
+                args=(
+                    *input_nodes,
+                    cm.info.page_size,
+                ),
+            )
+            metadata_nodes = [
+                graph.call_function(operator.getitem, args=(ret_node, idx))
+                for idx in range(num_metadata)
+            ]
+
+        buffer_in_lookup: Dict[str, Node] = {}
+
+        # replace fused attention node with attention node that has kv cache
+        num_cached_attn_replacements = 0
+        for idx, attn_node in enumerate(source_attn_nodes):
+            # pick out GEMMs
+            qkv = attn_node.args[: attn_descriptor.get_num_qkv_args()]
+
+            # setup + store cache initializers and caches as input nodes
+            cache_in_nodes = []
+            for k, get_cache in attn_descriptor.get_cache_initializers(
+                attn_node, cache_config
+            ).items():
+                k_indexed = f"{k}_{idx}"
+                cm.add_cache(k_indexed, get_cache)
+                cache_in_nodes.append(add_graph_input(gm, k_indexed))
+
+            # setup + store global buffer initializers and buffers as input nodes
+            # NOTE: we have to check against existing keys to make sure nothing is registered twice...
+            buffer_in_nodes = []
+            for k, get_buffer in attn_descriptor.get_global_buffer_initializers(attn_node).items():
+                if k not in buffer_in_lookup:
+                    cm.add_cache(k, get_buffer)
+                    buffer_in_lookup[k] = add_graph_input(gm, k)
+                buffer_in_nodes.append(buffer_in_lookup[k])  # store buffer nodes for this op
+
+            # retrieve constants for attention_op
+            constants = attn_descriptor.get_constants(attn_node)
+
+            # insert cached attention replacement op
+            with graph.inserting_before(attn_node):
+                cached_attn_node = graph.call_function(
+                    attn_descriptor.get_cached_attention_op(),
+                    args=(*qkv, *metadata_nodes, *cache_in_nodes, *buffer_in_nodes, *constants),
+                )
+            attn_node.replace_all_uses_with(cached_attn_node)
+            graph.erase_node(attn_node)
+            num_cached_attn_replacements += 1
+
+        info = TransformInfo(
+            skipped=False,
+            num_matches=num_cached_attn_replacements,
+            is_clean=False,
+            has_valid_shapes=False,
+        )
+
+        return gm, info
+
+
+class ResizeKVCacheConfig(TransformConfig):
+    """Configuration for the resize kv cache transform."""
+
+    free_mem_ratio: float = Field(
+        description="The fraction of available memory to occupy.", default=0.8
+    )
+
+
+@TransformRegistry.register("resize_kv_cache")
+class ResizeKVCache(BaseTransform):
+    """Inflate the kv cache to occupy the available GPU memory.
+
+    free_mem_ratio specifies the fraction of available memory to occupy.
+    """
+
+    config: ResizeKVCacheConfig
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return ResizeKVCacheConfig
+
+    def _apply(
+        self, gm: GraphModule, cm: CachedSequenceInterface, factory: ModelFactory
+    ) -> Tuple[GraphModule, TransformInfo]:
+        free_mem_ratio = self.config.free_mem_ratio
+
+        def _get_mem_info_in_mb():
+            free_mem, total_mem = torch.cuda.mem_get_info()
+            return free_mem // 1024**2, total_mem // 1024**2
+
+        free_mem, total_mem = _get_mem_info_in_mb()
+        ad_logger.info(f"Free memory (MB): {free_mem}, Total memory (MB): {total_mem}")
+        current_cache_size = cm.current_cache_size_bytes()
+        current_num_pages = cm.info.num_pages
+        ad_logger.info(
+            f"Current cache size: {current_cache_size}, Current num pages: {current_num_pages}"
+        )
+
+        if free_mem_ratio == 0.0:
+            ad_logger.info(f"Skipping cache resize for {free_mem_ratio=}")
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+
+        try:
+            # Let's run a forward pass to get the memory usage
+            cm.info._set_max_num_tokens_sample()
+            free_mem_pre, _ = _get_mem_info_in_mb()
+            ad_logger.info(f"Free memory before forward pass (MB): {free_mem_pre}")
+
+            gm(*cm.args)
+
+            free_mem_post, _ = _get_mem_info_in_mb()
+            ad_logger.info(f"Free memory after forward pass (MB): {free_mem_post}")
+
+            memory_for_forward_pass = free_mem_pre - free_mem_post
+            ad_logger.info(f"Memory for forward pass (MB): {memory_for_forward_pass}")
+
+            new_cache_size = free_mem_post * 1024 * 1024 * free_mem_ratio + current_cache_size
+            new_num_pages = int(new_cache_size // (current_cache_size // current_num_pages))
+
+            # Need to sync all the GPUs
+            gathered_num_pages = [None] * get_world_size()
+            all_gather_object(gathered_num_pages, new_num_pages)
+            new_num_pages = min(gathered_num_pages)
+            ad_logger.info(f"After all_gather - new_num_pages: {new_num_pages}")
+
+            cm.resize_cache(new_num_pages)
+        except Exception as e:
+            ad_logger.warning(
+                f"Error encountered while resizing kv cache: {e}.\nSkipping cache resize."
+            )
+
+        # Free memory
+        torch.cuda.empty_cache()
+
+        info = TransformInfo(
+            skipped=False,
+            num_matches=0,
+            is_clean=True,
+            has_valid_shapes=True,
+        )
+
+        return gm, info

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_graph_test_helpers.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_graph_test_helpers.py
@@ -8,6 +8,7 @@ from _torch_test_utils import all_close, reset_parameters
 from torch.export import export
 from torch.fx import GraphModule
 
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import SequenceInfo
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transformations.library.sharding import ShardingTransformInfo
 
@@ -20,6 +21,21 @@ class FakeFactory:
         return self.model.to(device=device)
 
 
+class SequenceEmbeddingInfo(SequenceInfo):
+    hidden_size: int
+    dtype: torch.dtype
+
+    def set_example_sequence(self) -> None:
+        super().set_example_sequence()
+        # set input ids to a 3D tensor (actually input embeddings)
+        self.input_ids = torch.rand(
+            *self.input_ids.shape,
+            self.hidden_size,
+            device=self.input_ids.device,
+            dtype=self.dtype,
+        )
+
+
 def count_parameters(model: torch.nn.Module):
     for n, p in model.named_parameters():
         print(n, p.shape)
@@ -30,6 +46,79 @@ def count_buffers(model: torch.nn.Module):
     for n, b in model.named_buffers():
         print(n, b.shape)
     return sum(np.prod(b.shape) for b in model.buffers())
+
+
+def run_test_transformed_gm(
+    model: nn.Module,
+    x: torch.Tensor,
+    gm_transformed: GraphModule,
+    check_transformed_graph: Callable[[GraphModule], bool],
+    _get_expected_num_params: Callable[[int], int],
+    atol: float = 1e-3,
+    rtol: float = 1e-3,
+    test_load_hook: bool = True,
+    strict_loading: bool = True,
+    dynamic_shapes: Dict = None,
+    skip_output_assert: bool = False,
+    *args,  # Additional arguments for transform
+) -> GraphModule:
+    # run model once
+    y_model = model(x)
+
+    # num params
+    num_params_model = count_parameters(model)
+    print(num_params_model)
+
+    # export + check (we clone the state dict to have a bit more freedom in testing below)
+    gm_ref = torch_export_to_gm(model, args=(x,), dynamic_shapes=(dynamic_shapes,), clone=True)
+    print(gm_ref)
+    y_gm = gm_ref(x)
+    num_params_gm = count_parameters(gm_ref)
+
+    assert num_params_model == num_params_gm
+    if not skip_output_assert:
+        torch.testing.assert_close(y_model, y_gm, atol=atol, rtol=rtol)
+
+    print(gm_transformed)
+    # in case buffers or other tensors were added during the transform
+    gm_transformed = gm_transformed.to("cuda")
+    y_transformed = gm_transformed(x)
+    n_p_transformed = count_parameters(gm_transformed)
+
+    n_p_t_expected = _get_expected_num_params(num_params_model)
+    assert n_p_transformed == n_p_t_expected, (
+        f"actual params {n_p_transformed} != expected params {n_p_t_expected}"
+    )
+
+    # check if the transformation worked
+    assert check_transformed_graph(gm_transformed)
+
+    if strict_loading and not skip_output_assert:
+        # check if output equals without loading state dict
+        torch.testing.assert_close(y_model, y_transformed, atol=atol, rtol=rtol)
+
+    if test_load_hook and not skip_output_assert:
+        # check if loading hook works from original state dict
+        reset_parameters(gm_transformed)
+        y_random = gm_transformed(x)
+        assert not all_close(y_model, y_random), f"{y_model=}, {y_random=}"
+
+        gm_transformed.load_state_dict(model.state_dict(), strict=True if strict_loading else False)
+        y_loaded_from_original = gm_transformed(x)
+        torch.testing.assert_close(y_model, y_loaded_from_original, atol=atol, rtol=rtol)
+
+        # check if loading hook works from state_dict of a transformed model
+        state_dict_sharded = copy.deepcopy(gm_transformed.state_dict())
+        reset_parameters(gm_transformed)
+        y_random2 = gm_transformed(x)
+        assert not all_close(y_model, y_random2), f"{y_model=}, {y_random2=}"
+
+        gm_transformed.load_state_dict(state_dict_sharded, strict=True if strict_loading else False)
+        y_loaded_from_transformed = gm_transformed(x)
+        torch.testing.assert_close(y_model, y_loaded_from_transformed, atol=atol, rtol=rtol)
+
+        # check if we can still export the model as expected
+        export(gm_transformed, args=(x,))
 
 
 def run_test(


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

[JIRA ticket/NVBugs ID/GitHub issue][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR to support a new feature about cache manager for JIRA ticket TRTLLM-1000, it would be like:

[TRTLLM-1000][feat] Support a new feature about cache manager

Or I have a PR to fix a Llama3 accuracy issue:

[https://nvbugs/1234567][fix] Fix Llama3 accuracy issue
-->

## Description
Issue #98 
This PR move kv cache transforms only.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage
- TRT-bench:
with modifications, tp=1:
```
```
target branch, tp=1:
```
Request Throughput (req/sec):                     39.2947
Total Output Throughput (tokens/sec):             5029.7223
Total Token Throughput (tokens/sec):              10059.4446
Total Latency (ms):                               25448.7211
Average request latency (ms):                     19921.6154
Per User Output Throughput [w/ ctx] (tps/user):   6.9288
Per GPU Output Throughput (tps/gpu):              5029.7223
```
with modification, tp=2:
```
```
target branch,tp=2:
```
```
<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
