### PR TITLE
Move fuse_collectives, fuse_moe, fuse_gemm to new inf optimizer

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -19,3 +19,7 @@ transforms:
     stage: post_export
   cleanup_input_constraints:
     stage: post_export
+  quantize:
+    stage: pattern_matcher
+  quantize_moe:
+    stage: pattern_matcher

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
@@ -7,7 +7,28 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-# TODO (nvchenghaoz): Remove related kernels once we have a backend-specific implementation for attention.
+
+def _apply_logit_softcapping(attn_scores: torch.Tensor, logit_cap: Optional[float]) -> torch.Tensor:
+    """Apply logit softcapping using the formula: logit_cap * tanh(logits / logit_cap)"""
+    if logit_cap is not None and logit_cap > 0.0:
+        return logit_cap * torch.tanh(attn_scores / logit_cap)
+    return attn_scores
+
+
+def _convert_boolean_mask_to_float(attn_mask: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    """Convert boolean attention mask to floating point mask.
+    Args:
+        attn_mask: Boolean tensor where True allows attention, False blocks it
+        dtype: Target dtype for the output mask
+    Returns:
+        Floating point mask where True -> 1.0, False -> -inf
+    """
+    if attn_mask.dtype == torch.bool:
+        float_mask = torch.zeros_like(attn_mask, dtype=dtype)
+        float_mask = float_mask.masked_fill(attn_mask, 1.0)  # True -> 1.0
+        float_mask = float_mask.masked_fill(~attn_mask, float("-inf"))  # False -> -inf
+        return float_mask
+    return attn_mask
 
 
 @torch.library.custom_op("auto_deploy::torch_attention_repeat_kv", mutates_args=())
@@ -77,19 +98,96 @@ def grouped_sdpa(
     dropout_p: float = 0.0,
     is_causal: bool = False,
     scale: Optional[float] = None,
+    sinks: Optional[torch.Tensor] = None,
+    sliding_window: Optional[int] = None,
+    logit_cap: Optional[float] = None,
 ) -> torch.Tensor:
-    """SDPA attention that can handle GQA."""
+    """SDPA attention that can handle GQA. Expects bnsd format inputs."""
+    b, n_heads, s_q, head_dim = query.shape  # bnsd format: [batch, num_heads, seq_len, head_dim]
+    _, n_kv_heads, s_k, _ = key.shape  # bnsd format: [batch, num_kv_heads, seq_len, head_dim]
 
-    return F.scaled_dot_product_attention(
-        query.contiguous(),
-        key.contiguous(),
-        value.contiguous(),
-        attn_mask=attn_mask,
-        dropout_p=dropout_p,
-        is_causal=is_causal,
-        scale=scale,
-        enable_gqa=True,
-    )
+    # Inputs are already in bnsd format, no need to transpose
+    query_t = query  # [b, n_heads, s_q, head_dim]
+    key_t = key  # [b, n_kv_heads, s_k, head_dim]
+    value_t = value  # [b, n_kv_heads, s_k, v_head_dim]
+
+    # Handle GQA by repeating KV if needed
+    if n_heads != n_kv_heads:
+        n_rep = n_heads // n_kv_heads
+        key_t = repeat_kv(key_t, n_rep)
+        value_t = repeat_kv(value_t, n_rep)
+
+    # Set scale
+    if scale is None:
+        scale = 1.0 / math.sqrt(head_dim)
+
+    # Compute attention scores: Q @ K^T
+    attn_scores = torch.matmul(query_t, key_t.transpose(-2, -1)) * scale  # [b, n_heads, s_q, s_k]
+
+    # Apply attention mask if provided
+    if attn_mask is not None:
+        # Convert boolean mask to float if needed
+        attn_mask = _convert_boolean_mask_to_float(attn_mask, attn_scores.dtype)
+        attn_scores = attn_scores + attn_mask
+
+    # Apply causal mask if specified and only during the context phase
+    if is_causal and s_q == s_k:  # Only apply causal mask during context processing
+        causal_mask = torch.triu(
+            torch.ones(s_q, s_k, device=query.device, dtype=torch.bool),
+            diagonal=1,  # Use diagonal=1 for standard causal masking
+        )
+        attn_scores.masked_fill_(causal_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+
+    # Apply sliding window mask if specified
+    if sliding_window is not None and sliding_window > 0:
+        # Handle position calculation for both context and generation phases
+        if s_q == s_k:
+            # Context phase: standard position calculation
+            query_positions = torch.arange(s_q, device=query.device)
+            key_positions = torch.arange(s_k, device=query.device)
+        else:
+            # Generation phase: query is at position s_k (after the cache)
+            query_positions = torch.arange(s_k, s_k + s_q, device=query.device)  # [s_k] for s_q=1
+            key_positions = torch.arange(s_k, device=query.device)  # [0,1,2,...,s_k-1]
+
+        # Create position difference matrix: query_pos - key_pos
+        pos_diff = query_positions.unsqueeze(1) - key_positions.unsqueeze(0)  # [s_q, s_k]
+
+        # Sliding window mask: allow attention only if 0 <= pos_diff < sliding_window_size
+        sliding_window_mask = (pos_diff < 0) | (pos_diff >= sliding_window)  # [s_q, s_k]
+        attn_scores.masked_fill_(sliding_window_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+
+    # Apply logit softcapping if enabled
+    attn_scores = _apply_logit_softcapping(attn_scores, logit_cap)
+
+    # Apply sinks if provided
+    if sinks is not None:
+        # Concatenate sinks to attention scores following the reference implementation
+        # sinks should have n_heads elements, each head gets its own sink value
+        # Expand sinks to [b, n_heads, s_q, 1] - one sink column per head
+        sinks_expanded = sinks.reshape(1, -1, 1, 1).expand(
+            b, n_heads, s_q, 1
+        )  # [b, n_heads, s_q, 1]
+
+        # Concatenate along the key dimension (last dimension)
+        logits_max = torch.max(attn_scores, dim=-1, keepdim=True).values
+        sinks = torch.exp(sinks_expanded - logits_max)
+        unnormalized_scores = torch.exp(attn_scores - logits_max)
+        normalizer = unnormalized_scores.sum(dim=-1, keepdim=True) + sinks
+        scores = unnormalized_scores / normalizer
+        # Use only the non-sink portion for computing output
+        # We added exactly 1 column, so remove exactly 1 column
+        attn_out = torch.matmul(scores, value_t)  # [b, n_heads, s_q, v_head_dim]
+    else:
+        attn_weights = torch.softmax(attn_scores, dim=-1, dtype=torch.float32).to(query.dtype)
+        attn_out = torch.matmul(attn_weights, value_t)  # [b, n_heads, s_q, v_head_dim]
+
+    # Apply dropout if specified
+    if dropout_p > 0.0:
+        attn_out = F.dropout(attn_out, p=dropout_p, training=False)
+
+    # Return in bnsd format (same as input format)
+    return attn_out
 
 
 @grouped_sdpa.register_fake
@@ -101,6 +199,9 @@ def grouped_sdpa_fake(
     dropout_p=0.0,
     is_causal=False,
     scale=None,
+    sinks=None,
+    sliding_window=None,
+    logit_cap=None,
 ):
     """Fake implementation of grouped SDPA."""
     return query.new_empty(*query.shape[:-1], value.shape[-1]).contiguous()
@@ -108,9 +209,9 @@ def grouped_sdpa_fake(
 
 @torch.library.custom_op("auto_deploy::torch_attention_bsnd_grouped_sdpa", mutates_args=())
 def bsnd_grouped_sdpa(
-    query: torch.Tensor,  # layout: [b, n, s_q, d]
-    key: torch.Tensor,  # layout: [b, n, s_k, d]
-    value: torch.Tensor,  # layout: [b, n, s_k, d]
+    query: torch.Tensor,  # layout: [b, s_q, n, d]
+    key: torch.Tensor,  # layout: [b, s_k, n, d]
+    value: torch.Tensor,  # layout: [b, s_k, n, d]
     attn_mask: Optional[torch.Tensor] = None,  # layout: [b, n, s_q, s_k]
     dropout_p: float = 0.0,
     is_causal: bool = False,
@@ -124,14 +225,16 @@ def bsnd_grouped_sdpa(
     Note that attn_mask layout is still assumed to be [b, n, s_q, s_k] and is consistent with the
     original sdpa op!
     """
-    # let's transpose to bnsd so we can use the grouped sdpa
-    query = query.transpose(1, 2).contiguous()
-    key = key.transpose(1, 2).contiguous()
-    value = value.transpose(1, 2).contiguous()
+    # Transpose inputs to bnsd format for grouped_sdpa
+    query = query.transpose(1, 2).contiguous()  # [b, s_q, n, d] -> [b, n, s_q, d]
+    key = key.transpose(1, 2).contiguous()  # [b, s_k, n, d] -> [b, n, s_k, d]
+    value = value.transpose(1, 2).contiguous()  # [b, s_k, n, d] -> [b, n, s_k, d]
 
-    out = grouped_sdpa(query, key, value, attn_mask, dropout_p, is_causal, scale)
-
-    # let's transpose back to bnsd
+    # Call grouped_sdpa with bnsd inputs
+    out = grouped_sdpa(
+        query, key, value, attn_mask, dropout_p, is_causal, scale, sinks, sliding_window, logit_cap
+    )
+    # Transpose back to bsnd format
     return out.transpose(1, 2).contiguous()
 
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/collectives.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/collectives.py
@@ -66,7 +66,6 @@ class FuseCollectives(BaseTransform):
             gm.graph.erase_node(parent_node)
             num_gemm_collective_fusions += 1
 
-        # TODO:(hg) confirm this
         info = TransformInfo(
             skipped=False,
             num_matches=num_gemm_collective_fusions,
@@ -190,7 +189,6 @@ class FuseAllreduceResidualRMSNorm(BaseTransform):
             if is_op(node, torch.ops.auto_deploy.torch_dist_all_reduce):
                 trace_and_fuse(allreduce_node=node, graph=gm.graph)
 
-        # TODO:(hg) confirm this
         info = TransformInfo(
             skipped=False, num_matches=num_ar_r_rms_fusions, is_clean=False, has_valid_shapes=False
         )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/collectives.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/collectives.py
@@ -1,0 +1,198 @@
+import operator
+from typing import Tuple
+
+import torch
+from torch.fx import GraphModule
+
+from ...distributed.trtllm import is_trtllm_op_available
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface
+from ...utils.node_utils import get_op_overload_packet, get_user_if_pattern_match, is_op
+from ..interface import BaseTransform, TransformInfo, TransformRegistry
+
+# TODO: This is an overly simplified model that works well for vanilla Llama models.
+# However, we eventually want to consider more sophisticated patterns such as
+# * all_reduce(lin1(x) + lin2(x))
+# * version above with fused GEMMs (i.e. with a split node)
+# * all_reduce(pointwise_op(linear(x)))
+# * ...
+
+
+@TransformRegistry.register("fuse_collectives")
+class FuseCollectives(BaseTransform):
+    """
+    Fuses all_reduce ops with preceding (quantized) linear ops into a single fused node for improved performance.
+    """
+
+    def _apply(
+        self, gm: GraphModule, cm: CachedSequenceInterface, factory: ModelFactory
+    ) -> Tuple[GraphModule, TransformInfo]:
+        num_gemm_collective_fusions = 0
+
+        # lookup for fused ops
+        # TODO: avoid this hardcoded lookup, e.g., by generating fused ops on the fly.
+        lookup = {
+            torch.ops.auto_deploy.torch_linear_simple: torch.ops.auto_deploy.trtllm_dist_fused_linear_all_reduce,
+            torch.ops.aten.linear: torch.ops.auto_deploy.trtllm_dist_fused_linear_all_reduce,
+            torch.ops.auto_deploy.torch_quant_fp8_linear: torch.ops.auto_deploy.torch_quant_fused_fp8_linear_all_reduce,
+        }
+
+        # go through all nodes and find all_reduce nodes
+        for node in gm.graph.nodes:
+            if not is_op(node, torch.ops.auto_deploy.torch_dist_all_reduce):
+                continue
+
+            # check if args are as expected
+            assert len(node.args) == 1 and not len(node.kwargs), (
+                "Unexpected args/kwargs for all_reduce"
+            )
+
+            # retrieve parent and check a few conditions on the parent node
+            parent_node = node.args[0]
+            if not is_op(parent_node, lookup.keys()):
+                continue
+            if len(parent_node.users) > 1:
+                continue
+
+            with gm.graph.inserting_before(node):
+                # insert fused node
+                fused_linear_collective_node = gm.graph.call_function(
+                    lookup[get_op_overload_packet(parent_node.target)],
+                    args=parent_node.args,
+                    kwargs=parent_node.kwargs,
+                )
+            node.replace_all_uses_with(fused_linear_collective_node)
+            gm.graph.erase_node(node)
+            gm.graph.erase_node(parent_node)
+            num_gemm_collective_fusions += 1
+
+        # TODO:(hg) confirm this
+        info = TransformInfo(
+            skipped=False,
+            num_matches=num_gemm_collective_fusions,
+            is_clean=False,
+            has_valid_shapes=False,
+        )
+
+        return gm, info
+
+
+@TransformRegistry.register("fuse_allreduce_residual_rmsnorm")
+class FuseAllreduceResidualRMSNorm(BaseTransform):
+    """Essentially, this transformation fuses the following operators into one allreduce trtllm implementation.
+
+    * target pattern:
+        x = all_reduce(x)
+        y = x + residual
+        return rmsnorm(y), y
+    * replacement:
+        fused_allreduce_residual_rmsnorm(x, residual, rmsnorm_weight, rmsnorm_eps)
+
+    """
+
+    def _apply(
+        self, gm: GraphModule, cm: CachedSequenceInterface, factory: ModelFactory
+    ) -> Tuple[GraphModule, TransformInfo]:
+        if not is_trtllm_op_available():
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+
+        num_ar_r_rms_fusions = 0
+
+        def trace_and_fuse(allreduce_node, graph):
+            # Check if all_reduce is followed by addition
+            users = list(allreduce_node.users.keys())
+            if len(users) != 1:
+                return  # Skip if all_reduce has more than one consumer
+            add_node = users[0]
+
+            # Traverse nodes for RMSNorm pattern which is composed of to_copy, pow, mean, add, refer
+            # the Huggingface LlamaRMSNorm implementation as example for more details
+            to_copy_1 = get_user_if_pattern_match(add_node, [torch.ops.aten.add, operator.add], 2)
+            # operand of pow and mul
+            pow_node = get_user_if_pattern_match(
+                to_copy_1, [torch.ops.aten._to_copy, torch.ops.aten.to], 2
+            )
+            mean_node = get_user_if_pattern_match(pow_node, torch.ops.aten.pow, 1)
+            add_eps_node = get_user_if_pattern_match(mean_node, torch.ops.aten.mean, 1)
+            rsqrt_node = get_user_if_pattern_match(
+                add_eps_node, [torch.ops.aten.add, operator.add], 1
+            )
+            mul_node_1 = get_user_if_pattern_match(rsqrt_node, torch.ops.aten.rsqrt, 1)
+            to_copy_2 = get_user_if_pattern_match(mul_node_1, torch.ops.aten.mul, 1)
+            mul_node_2 = get_user_if_pattern_match(
+                to_copy_2, [torch.ops.aten._to_copy, torch.ops.aten.to], 1
+            )
+            # check args of ops: pow(2) and mean(-1)
+            ARGS_MATCH = pow_node is not None and pow_node.args[1] == 2  # exponent
+            ARGS_MATCH &= mean_node is not None and mean_node.args[1] == [-1]  # dimensions
+
+            # Match found: Replace with fused operation
+            if (
+                to_copy_1
+                and pow_node
+                and mean_node
+                and add_eps_node
+                and rsqrt_node
+                and mul_node_1
+                and to_copy_2
+                and mul_node_2
+                and ARGS_MATCH
+            ):
+                # Gather the inputs for the custom operation
+                tensor = allreduce_node.args[0]
+                # Identify the residual argument in the add operation
+                # One of the args in add_node.args is the output of all_reduce
+                # The same idea also applies to norm_weight
+                residual = (
+                    add_node.args[0] if add_node.args[1] is allreduce_node else add_node.args[1]
+                )
+                norm_weight = (
+                    mul_node_2.args[0] if mul_node_2.args[1] is to_copy_2 else mul_node_2.args[1]
+                )
+                eps = add_eps_node.args[1]
+
+                # Insert nodes
+                with graph.inserting_before(allreduce_node):
+                    fused_node = graph.call_function(
+                        torch.ops.dist.fused_allreduce_residual_rmsnorm,
+                        args=(
+                            tensor,
+                            residual,
+                            norm_weight,
+                            eps,
+                        ),
+                    )
+                    # Extract outputs from the tuple returned by `fused_node`
+                    final_output_node = gm.graph.create_node(
+                        "call_function",
+                        target=operator.getitem,
+                        args=(fused_node, 0),
+                    )
+                    add_output_node = gm.graph.create_node(
+                        "call_function",
+                        target=operator.getitem,
+                        args=(fused_node, 1),
+                    )
+
+                    # Replace all uses of rmsnorm_node with final_output_node
+                    mul_node_2.replace_all_uses_with(final_output_node)
+
+                    # Replace all uses of add_node with add_output_node
+                    add_node.replace_all_uses_with(add_output_node)
+
+                nonlocal num_ar_r_rms_fusions
+                num_ar_r_rms_fusions += 1
+
+        # Traverse all nodes
+        for node in gm.graph.nodes:
+            if is_op(node, torch.ops.auto_deploy.torch_dist_all_reduce):
+                trace_and_fuse(allreduce_node=node, graph=gm.graph)
+
+        # TODO:(hg) confirm this
+        info = TransformInfo(
+            skipped=False, num_matches=num_ar_r_rms_fusions, is_clean=False, has_valid_shapes=False
+        )
+
+        return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_moe.py
@@ -1,0 +1,515 @@
+from collections import defaultdict
+from typing import Optional, Tuple
+
+import torch
+from torch.fx import GraphModule, Node
+
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface
+from ...utils.cuda_mem_tracker import cuda_memory_tracker
+from ...utils.node_utils import bfs, identify_regions_between_residuals, is_linear_op, is_op
+from ...utils.quantization_utils import get_scales_and_type_from_node
+from ..interface import BaseTransform, TransformInfo, TransformRegistry
+
+
+def _insert_fused_moe_ops(gm: GraphModule) -> int:
+    fused_key_counter = 0
+    graph = gm.graph
+
+    for node in list(graph.nodes):
+        if not is_op(node, torch.ops.auto_deploy.torch_moe):
+            continue
+
+        hidden_states, selected_experts, routing_weights, w1_list, w2_list, w3_list = node.args
+
+        fused_w3_w1_experts = torch.stack(
+            [
+                torch.cat(
+                    [gm.get_parameter(w3_node.target), gm.get_parameter(w1_node.target)], dim=-2
+                )
+                for w1_node, w3_node in zip(w1_list, w3_list)
+            ],
+            dim=0,
+        )
+
+        fused_w2_experts = torch.stack([gm.get_parameter(n.target) for n in w2_list], dim=0)
+
+        new_key_w3_w1 = f"fused_moe_w3_w1_stacked_{fused_key_counter}"
+        new_key_w2 = f"fused_moe_w2_stacked_{fused_key_counter}"
+        fused_key_counter += 1
+        param_w3_w1 = torch.nn.Parameter(fused_w3_w1_experts)
+        param_w2 = torch.nn.Parameter(fused_w2_experts)
+        gm.register_parameter(new_key_w3_w1, param_w3_w1)
+        gm.register_parameter(new_key_w2, param_w2)
+
+        with graph.inserting_before(node):
+            new_node = graph.call_function(
+                # TODO(Fridah-nv): torch.ops.auto_deploy.trtllm_moe_fused for quantized models
+                torch.ops.auto_deploy.trtllm_moe_fused,
+                args=(
+                    hidden_states,
+                    selected_experts,
+                    routing_weights,
+                    graph.get_attr(new_key_w3_w1),
+                    graph.get_attr(new_key_w2),
+                ),
+            )
+
+        node.replace_all_uses_with(new_node)
+        graph.erase_node(node)
+
+    return fused_key_counter
+
+
+def _find_lowest_common_ancessor(nodes: list[Node]) -> Optional[Node]:
+    """
+    Find the lowest common ancestor for a list of nodes in a torch.fx Graph by following
+    each node's primary branch (recursively following the first Node argument).
+
+    It first finds the LCA of the first two nodes and then
+    iteratively computes the LCA of the result with the next node, and so on.
+
+    Returns:
+        The common ancestor Node if found, otherwise None.
+    """
+    if not nodes:
+        return None
+
+    def get_parent(node: Node) -> Optional[Node]:
+        """Return the first Node-valued argument for a given node, or None if not found."""
+        for arg in node.args:
+            if isinstance(arg, Node):
+                return arg
+        return None
+
+    def get_depth(node: Node) -> int:
+        """
+        Recursively compute the depth of the node by following its primary branch.
+        Depth is defined as the number of steps to reach a node with no parent.
+        """
+        parent = get_parent(node)
+        if parent is None:
+            return 0
+        return 1 + get_depth(parent)
+
+    def lca_two(a: Node, b: Node) -> Optional[Node]:
+        """
+        Find the lowest common ancestor of two nodes by first equalizing their depth
+        and then moving upward until a common node is found.
+        """
+        depth_a = get_depth(a)
+        depth_b = get_depth(b)
+
+        # Equalize depths
+        while depth_a > depth_b:
+            a = get_parent(a)
+            depth_a -= 1
+        while depth_b > depth_a:
+            b = get_parent(b)
+            depth_b -= 1
+
+        # Walk upward in lockstep
+        while a is not None and b is not None:
+            if a is b:
+                return a
+            a = get_parent(a)
+            b = get_parent(b)
+        return None
+
+    # Iteratively compute the LCA across all nodes.
+    common = nodes[0]
+    for node in nodes[1:]:
+        common = lca_two(common, node)
+        if common is None:
+            return None
+
+    return common
+
+
+def _extract_linear_parameters(linear_node: Node) -> tuple[Node, torch.Tensor, Optional[dict], str]:
+    """
+    Given a linear op node, extract the input tensor node, weight tensor,
+    any quantization scales (if the op is quantized), and return a weight type.
+
+    For a torch.ops.auto_deploy.torch_linear_simple.default op:
+      - Returns (input_node, weight, None, "simple")
+
+    For a torch.ops.auto_deploy.torch_quant_fp8_linear op:
+      - Returns (input_node, weight, {"input_scale": input_scale, "weight_scale": weight_scale}, "fp8")
+       For a torch.ops.auto_deploy.torch_quant_fp4_linear op:
+      - Returns (input_node, weight, {"input_scale": input_scale, "weight_scale": weight_scale, "alpha": alpha}, "fp4")
+    """
+    input_node = linear_node.args[0]
+    if is_op(linear_node, torch.ops.auto_deploy.torch_linear_simple):
+        weight = linear_node.args[1]
+        return input_node, weight, None, ""
+    elif {
+        is_op(linear_node, torch.ops.auto_deploy.torch_quant_fp4_linear),
+        is_op(linear_node, torch.ops.auto_deploy.torch_quant_fp8_linear),
+    }:
+        weight = linear_node.args[1]
+        scales, quant_type = get_scales_and_type_from_node(linear_node)
+        return input_node, weight, scales, quant_type
+
+
+def _match_expert_compute_pattern(start_boundary: Node, end_boundary: Node):
+    """
+    Match the expert compute pattern between the given boundaries.
+
+    The expert compute pattern corresponds to:
+
+        (F.silu(x @ w1.t()) * (x @ w3.t())) @ w2.t()
+
+    For each expert, the function extracts the input node from the w1 branch and
+    collects the weight parameters from three linear ops (w1, w3, and w2 branches).
+
+    This function supports both:
+      - torch.ops.auto_deploy.torch_linear_simple.default ops, and
+      - torch.ops.auto_deploy.torch_quant_fp8_linear ops (also extracts quantization scales).
+      - torch.ops.auto_deploy.torch_quant_fp4_linear ops (also extracts quantization scales).
+
+    Returns:
+        A tuple:
+          (pattern_input_nodes, pattern_output_nodes, expert_weights, expert_scales, weight_type)
+
+          - pattern_input_nodes: List of input nodes (x) used for the expert compute.
+          - pattern_output_nodes: List of final expert output nodes (the linear op with weight w2).
+          - expert_weights: Dict with keys "w1", "w2", "w3" mapping to lists of weight tensors.
+          - expert_scales: Dict with keys "w1_input_scale", "w1_weight_scale", etc., containing scale tensors
+                           (empty if weight_type is "simple").
+          - weight_type: "fp8" if FP8 ops were used, "simple" otherwise.
+    """
+    pattern_input_nodes, pattern_output_nodes = [], []
+    expert_weights = defaultdict(list)
+    expert_scales = defaultdict(list)
+    weight_type = "simple"  # default
+
+    nodes = list(start_boundary.graph.nodes)
+    region_nodes = nodes[nodes.index(start_boundary) + 1 : nodes.index(end_boundary)]
+
+    for node in region_nodes:
+        # Accept both simple and quantized linear ops.
+        if not is_linear_op(node, include_quantization=True):
+            continue
+
+        final_linear = node
+        if not final_linear.args or not isinstance(final_linear.args[0], Node):
+            continue
+
+        mul_node = final_linear.args[0]
+        if not is_op(mul_node, torch.ops.aten.mul) or len(mul_node.args) < 2:
+            continue
+
+        arg_a, arg_b = mul_node.args[:2]
+        silu_node = (
+            arg_a
+            if is_op(arg_a, torch.ops.aten.silu)
+            else arg_b
+            if is_op(arg_b, torch.ops.aten.silu)
+            else None
+        )
+        if silu_node is None:
+            continue
+
+        if not (silu_node.args and is_linear_op(silu_node.args[0], include_quantization=True)):
+            continue
+        linear_w1_node = silu_node.args[0]
+
+        # The other branch should be a linear op (w3 branch).
+        linear_w3_node = arg_b if arg_a is silu_node else arg_a
+        if not is_linear_op(linear_w3_node, include_quantization=True):
+            continue
+        if not (linear_w1_node.args and linear_w3_node.args):
+            continue
+
+        # Extract parameters from each linear op.
+        input_node_w1, weight_w1, quant_params_w1, wt_type_w1 = _extract_linear_parameters(
+            linear_w1_node
+        )
+        _, weight_w3, quant_params_w3, wt_type_w3 = _extract_linear_parameters(linear_w3_node)
+        _, weight_w2, quant_params_w2, wt_type_w2 = _extract_linear_parameters(final_linear)
+
+        if None in (weight_w1, weight_w3, weight_w2):
+            continue
+
+        # Ensure the weight type is consistent across branches.
+        if wt_type_w1 != wt_type_w3 or wt_type_w1 != wt_type_w2:
+            continue
+        weight_type = wt_type_w1
+
+        pattern_input_nodes.append(input_node_w1)
+        pattern_output_nodes.append(final_linear)
+        expert_weights["w1"].append(weight_w1)
+        expert_weights["w3"].append(weight_w3)
+        expert_weights["w2"].append(weight_w2)
+
+        # TODO: sanity check that all experts have same weight type
+        if weight_type == "fp8":
+            expert_scales["w1_input_scale"].append(quant_params_w1["input_scale"])
+            expert_scales["w1_weight_scale"].append(quant_params_w1["weight_scale"])
+            expert_scales["w3_input_scale"].append(quant_params_w3["input_scale"])
+            expert_scales["w3_weight_scale"].append(quant_params_w3["weight_scale"])
+            expert_scales["w2_input_scale"].append(quant_params_w2["input_scale"])
+            expert_scales["w2_weight_scale"].append(quant_params_w2["weight_scale"])
+        elif weight_type == "fp4":
+            expert_scales["w1_input_scale"].append(quant_params_w1["input_scale"])
+            expert_scales["w1_weight_scale"].append(quant_params_w1["weight_scale"])
+            expert_scales["w1_alpha"].append(quant_params_w1["alpha"])
+            expert_scales["w3_input_scale"].append(quant_params_w3["input_scale"])
+            expert_scales["w3_weight_scale"].append(quant_params_w3["weight_scale"])
+            expert_scales["w3_alpha"].append(quant_params_w3["alpha"])
+            expert_scales["w2_input_scale"].append(quant_params_w2["input_scale"])
+            expert_scales["w2_weight_scale"].append(quant_params_w2["weight_scale"])
+            expert_scales["w2_alpha"].append(quant_params_w2["alpha"])
+
+    return pattern_input_nodes, pattern_output_nodes, expert_weights, expert_scales, weight_type
+
+
+def _find_final_hidden_state_node(
+    pattern_output_nodes: list[Node], end_boundary: Node
+) -> Optional[Node]:
+    """
+    Identify the final hidden state node corresponding to the combine pattern:
+
+        (expert_output * routing_weight) → index_add_
+
+    For each expert output node (from the expert compute pattern), this function:
+      1. Retrieves a multiplication node from its users.
+      2. Extracts the second argument from the multiplication node (assumed to be the index node).
+      3. Uses a BFS to locate the subsequent index_add_ node (guarded by the end_boundary).
+
+    After collecting all such index_add_ nodes, the final hidden state node is determined
+    as the one that is not used by any of the other index_add_ nodes.
+
+    If any required attribute (users or args) is missing during the process or if no valid
+    final node is found, the function returns None.
+    """
+
+    if not pattern_output_nodes:
+        return None
+
+    index_add_nodes = []
+    for node in pattern_output_nodes:
+        if not node.users:
+            return None
+        mul_node = next(iter(node.users))
+        if not (hasattr(mul_node, "args") and len(mul_node.args) >= 2):
+            return None
+        index_node = mul_node.args[1]
+        index_add_node = bfs(
+            index_node, lambda n: is_op(n, torch.ops.aten.index_add_), boundary=end_boundary
+        )
+        if not index_add_node:
+            return None
+        index_add_nodes.append(index_add_node)
+
+    # The final node is defined as the index_add_node that is not used by any other index_add_nodes
+    return next(
+        (
+            candidate
+            for candidate in index_add_nodes
+            if not any(
+                candidate in other.args for other in index_add_nodes if candidate is not other
+            )
+        ),
+        None,
+    )
+
+
+def _extract_index_branches_from_expert_outputs(
+    pattern_output_nodes: list[Node],
+) -> tuple[list[Node], list[Node]]:
+    """
+    Extract routing and experts branches from expert outputs.
+
+    For each expert output, find its multiplication user. From the
+    multiplication node's second argument (an index node),
+    extract:
+      - The first argument as the routing branch.
+      - The second argument (flattened if a list/tuple) as the experts branch.
+
+    Returns:
+        A tuple (routing_branches, experts_branches).
+    """
+    routing_branches, experts_branches = [], []
+    for out in pattern_output_nodes:
+        mul = next((u for u in out.users if is_op(u, torch.ops.aten.mul)), None)
+        if not mul or len(mul.args) < 2:
+            continue
+        idx_node = mul.args[1]
+        if not is_op(idx_node, torch.ops.aten.index):
+            continue
+        routing_branches.append(idx_node.args[0])
+        experts = idx_node.args[1]
+        experts_branches.extend(experts) if isinstance(
+            experts, (list, tuple)
+        ) else experts_branches.append(experts)
+    return routing_branches, experts_branches
+
+
+def _remove_dead_inplace_nodes_in_region(
+    graph: torch.fx.Graph,
+    start_boundary: torch.fx.Node,
+    end_boundary: torch.fx.Node,
+) -> bool:
+    """
+    Searches (via BFS) for a dead in-place node (index_add_) in the region
+    between start_boundary and end_boundary. If one is found, it is removed from the graph.
+    Returns True if a node was removed, False otherwise.
+    """
+
+    def target(n: torch.fx.Node) -> bool:
+        return is_op(n, {torch.ops.aten.index_add_}) and len(n.users) == 0
+
+    try:
+        node_to_remove = bfs(start_boundary, target, attr_next="users", boundary=end_boundary)
+        graph.erase_node(node_to_remove)
+        return True
+    except RuntimeError:
+        return False
+
+
+@TransformRegistry.register("match_moe_pattern")
+class MatchMoePattern(BaseTransform):
+    def _apply(
+        self, gm: GraphModule, cm: CachedSequenceInterface, factory: ModelFactory
+    ) -> Tuple[GraphModule, TransformInfo]:
+        graph = gm.graph
+
+        # Preprocessing: Identify boundary nodes (e.g. residual connections) in the graph.
+        boundary_nodes = identify_regions_between_residuals(gm)
+
+        num_moe_patterns = 0
+
+        for start_boundary, end_boundary in zip(boundary_nodes[:-1], boundary_nodes[1:]):
+            # Step 1: Identify Expert Compute pattern
+            (
+                pattern_input_nodes,
+                pattern_output_nodes,
+                expert_weights,
+                expert_scales,
+                weight_type,
+            ) = _match_expert_compute_pattern(start_boundary, end_boundary)
+            if not expert_weights:
+                continue
+            # TODO: naming convention to verify the order of the weight nodes
+
+            # Step 2: Trace upwards to locate normalize_routing_weight and selected_experts:
+            arg1_list, arg2_list = _extract_index_branches_from_expert_outputs(pattern_output_nodes)
+            normalized_routing_weights = _find_lowest_common_ancessor(arg1_list)
+            if not normalized_routing_weights:
+                continue
+
+            common_ancessor2 = _find_lowest_common_ancessor(arg2_list)
+            if not common_ancessor2:
+                continue
+            selected_experts = bfs(
+                common_ancessor2,
+                lambda node: is_op(node, torch.ops.aten.one_hot),
+                attr_next="all_input_nodes",
+                boundary=start_boundary,
+            ).args[0]
+            if not selected_experts:
+                continue
+
+            # Step 3: Trace upwards to find input node:
+            hidden_states = _find_lowest_common_ancessor(pattern_input_nodes)
+            if not hidden_states:
+                continue
+
+            # Step 4: Find output node with the combine pattern
+            final_hidden_state_node = _find_final_hidden_state_node(
+                pattern_output_nodes, end_boundary
+            )
+            if final_hidden_state_node is None:
+                continue
+
+            # Step 5: Insert the MoE op into the graph.
+            with graph.inserting_before(final_hidden_state_node):
+                w1_list = expert_weights["w1"]
+                w2_list = expert_weights["w2"]
+                w3_list = expert_weights["w3"]
+
+                if weight_type == "fp8":
+                    fused_moe_node = graph.call_function(
+                        torch.ops.auto_deploy.torch_quant_fp8_moe,
+                        args=(
+                            hidden_states,
+                            selected_experts,
+                            normalized_routing_weights,
+                            w1_list,
+                            w2_list,
+                            w3_list,
+                            expert_scales["w1_input_scale"],
+                            expert_scales["w2_input_scale"],
+                            expert_scales["w3_input_scale"],
+                            expert_scales["w1_weight_scale"],
+                            expert_scales["w2_weight_scale"],
+                            expert_scales["w3_weight_scale"],
+                        ),
+                    )
+                elif weight_type == "fp4":
+                    fused_moe_node = graph.call_function(
+                        torch.ops.auto_deploy.torch_quant_fp4_moe,
+                        args=(
+                            hidden_states,
+                            selected_experts,
+                            normalized_routing_weights,
+                            w1_list,
+                            w2_list,
+                            w3_list,
+                            expert_scales["w1_input_scale"],
+                            expert_scales["w2_input_scale"],
+                            expert_scales["w3_input_scale"],
+                            expert_scales["w1_weight_scale"],
+                            expert_scales["w2_weight_scale"],
+                            expert_scales["w3_weight_scale"],
+                            expert_scales["w1_alpha"],
+                            expert_scales["w2_alpha"],
+                            expert_scales["w3_alpha"],
+                        ),
+                    )
+                else:
+                    fused_moe_node = graph.call_function(
+                        torch.ops.auto_deploy.torch_moe,
+                        args=(
+                            hidden_states,
+                            selected_experts,
+                            normalized_routing_weights,
+                            w1_list,
+                            w2_list,
+                            w3_list,
+                        ),
+                    )
+
+            final_hidden_state_node.replace_all_uses_with(fused_moe_node)
+            graph.erase_node(final_hidden_state_node)
+
+            while _remove_dead_inplace_nodes_in_region(gm.graph, start_boundary, end_boundary):
+                gm.graph.eliminate_dead_code()
+
+            num_moe_patterns += 1
+
+        info = TransformInfo(
+            skipped=False, num_matches=num_moe_patterns, is_clean=False, has_valid_shapes=True
+        )
+        return gm, info
+
+
+@TransformRegistry.register("fuse_moe")
+class FuseMoe(BaseTransform):
+    """
+    Scan the FX graph and replace all calls to torch.ops.auto_deploy.torch_moe with
+    torch.ops.auto_deploy.trtllm_moe_fused.
+    """
+
+    def _apply(
+        self, gm: GraphModule, cm: CachedSequenceInterface, factory: ModelFactory
+    ) -> Tuple[GraphModule, TransformInfo]:
+        with cuda_memory_tracker():
+            fused_key_counter = _insert_fused_moe_ops(gm)
+
+        info = TransformInfo(
+            skipped=False, num_matches=fused_key_counter, is_clean=False, has_valid_shapes=True
+        )
+        return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_moe.py
@@ -491,7 +491,7 @@ class MatchMoePattern(BaseTransform):
             num_moe_patterns += 1
 
         info = TransformInfo(
-            skipped=False, num_matches=num_moe_patterns, is_clean=False, has_valid_shapes=True
+            skipped=False, num_matches=num_moe_patterns, is_clean=False, has_valid_shapes=False
         )
         return gm, info
 
@@ -510,6 +510,6 @@ class FuseMoe(BaseTransform):
             fused_key_counter = _insert_fused_moe_ops(gm)
 
         info = TransformInfo(
-            skipped=False, num_matches=fused_key_counter, is_clean=False, has_valid_shapes=True
+            skipped=False, num_matches=fused_key_counter, is_clean=False, has_valid_shapes=False
         )
         return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fusion.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fusion.py
@@ -144,6 +144,6 @@ class FuseGemms(BaseTransform):
         torch.cuda.empty_cache()
 
         info = TransformInfo(
-            skipped=False, num_matches=num_matches, is_clean=False, has_valid_shapes=True
+            skipped=False, num_matches=num_matches, is_clean=False, has_valid_shapes=False
         )
         return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fusion.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fusion.py
@@ -1,0 +1,149 @@
+import operator
+from collections import defaultdict
+from typing import List, Tuple
+
+import torch
+import torch.nn as nn
+from torch.fx import GraphModule, Node
+
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface
+from ...utils.cuda_mem_tracker import cuda_memory_tracker
+from ...utils.logger import ad_logger
+from ...utils.node_utils import (
+    extract_param_names_from_lin_node,
+    get_op_overload_packet,
+    is_linear_op,
+)
+from ...utils.quantization_utils import QuantizationImpl
+from ..interface import BaseTransform, TransformInfo, TransformRegistry
+
+
+def _insert_fused_gemm(gm: GraphModule, idx: int, parent_node: Node, linear_nodes: List[Node]):
+    """Fuse GEMMs that have the same input activation.
+
+    Below, is a simple example of how the fusion works:
+
+    # before fusion:
+    w1 = out1 x in
+    w2 = out2 x in
+    x = b x in
+    y1 = x @ w1.T = b x out1
+    y2 = x @ w2.T = b x out2
+
+    # after fusion
+    w = out1+out2 x in
+    y = x @ w.T = b x (out1+out2)
+    y1 = y[:, :out1]
+    y2 = y[:, out1:out1+out2]
+    """
+    # some info we need
+    keys_unfused = [extract_param_names_from_lin_node(n)[0] for n in linear_nodes]
+    params_unfused = [gm.get_parameter(k) for k in keys_unfused]
+    sizes_unfused = [p.size(0) for p in params_unfused]
+    key_fused = f"fused_weight_{idx}"
+
+    quantization_impls = [QuantizationImpl.create(n) for n in linear_nodes]
+
+    def fuse_weights(tensors: List[torch.Tensor]) -> torch.Tensor:
+        """Fuse weights of linear nodes."""
+        return torch.cat(tensors, dim=0)
+
+    def split_output(tensor: torch.Tensor) -> Tuple[torch.Tensor, ...]:
+        """Split the output tensor of the fused linear node to obtain the original outputs."""
+        return tuple(t.contiguous() for t in torch.split(tensor, sizes_unfused, dim=-1))
+
+    if all(
+        q is not None and quantization_impls[0].target_op() == q.target_op()
+        for q in quantization_impls
+    ):
+        scales = {}
+        for weight_key in keys_unfused:
+            key = weight_key.rsplit(".", 1)[0]
+
+            for scale_name in quantization_impls[0].scale_names():
+                buffer_name = key + "." + scale_name
+                scales.setdefault(scale_name, []).append(gm.get_buffer(buffer_name))
+
+        try:
+            weights_fused, buffer_fused = quantization_impls[0].fuse_linear_weights(
+                params_unfused, **scales
+            )
+        except NotImplementedError as e:
+            ad_logger.warning(f"Cannot fuse ops {keys_unfused}, skipping: {e}")
+            return
+        param_fused = nn.Parameter(weights_fused, requires_grad=False)
+
+        for scale_name, buffer in buffer_fused.items():
+            fused_buffer_name = key_fused + "_" + scale_name
+            gm.register_buffer(fused_buffer_name, buffer)
+
+    elif all(q is None for q in quantization_impls):
+        param_fused = nn.Parameter(fuse_weights([gm.get_parameter(k) for k in keys_unfused]))
+    else:
+        ad_logger.warning(f"Cannot fuse ops {keys_unfused} for mixed-precision linear nodes.")
+        return
+
+    setattr(gm, key_fused, param_fused)
+
+    # Handle fused_kwargs for quantized fused gemm.
+    fused_kwargs = dict(linear_nodes[0].kwargs)
+
+    with gm.graph.inserting_before(linear_nodes[0]):
+        get_param_node = gm.graph.get_attr(key_fused, torch.Tensor)
+        if quantization_impls[0]:
+            for scale_name in quantization_impls[0].scale_names():
+                # Creates new nodes for the fused scales so the unfused linear ops can be fully erased.
+                fused_kwargs[scale_name] = gm.graph.create_node(
+                    "get_attr", key_fused + "_" + scale_name
+                )
+
+    # add new linear node + split node
+    with gm.graph.inserting_before(linear_nodes[0]):
+        fused_linear_node = gm.graph.call_function(
+            get_op_overload_packet(linear_nodes[0].target),
+            args=(parent_node, get_param_node, None),
+            kwargs=fused_kwargs,  # Assuming the scaling factors are the same
+        )
+        split_node = gm.graph.call_function(split_output, args=(fused_linear_node,))
+
+    # now we need to replace all the linear nodes with the correct index of the split node
+    for i, n in enumerate(linear_nodes):
+        with gm.graph.inserting_before(n):
+            get_split_node = gm.graph.call_function(operator.getitem, args=(split_node, i))
+        n.replace_all_uses_with(get_split_node)
+
+    # Clean up deleted modules to save GPU memory
+    gm.graph.eliminate_dead_code()
+    gm.delete_all_unused_submodules()
+
+
+@TransformRegistry.register("fuse_gemms")
+class FuseGemms(BaseTransform):
+    def _apply(
+        self, gm: GraphModule, cm: CachedSequenceInterface, factory: ModelFactory
+    ) -> Tuple[GraphModule, TransformInfo]:
+        # sort linear nodes by parent node
+        linear_nodes = defaultdict(list)
+        for node in gm.graph.nodes:
+            # TODO: we don't handle bias for now...
+            if is_linear_op(node, include_quantization=True) and node.args[2] is None:
+                linear_nodes[node.args[0]].append(node)
+
+        # fuse linear nodes
+        idx = -1
+        num_matches = 0
+        with cuda_memory_tracker():
+            for parent_node, lin_children in linear_nodes.items():
+                if len(lin_children) < 2:
+                    continue
+                # linear nodes to fuse
+                _insert_fused_gemm(gm, idx := idx + 1, parent_node, lin_children)
+                num_matches += 1
+
+        torch.cuda.empty_cache()
+
+        info = TransformInfo(
+            skipped=False, num_matches=num_matches, is_clean=False, has_valid_shapes=True
+        )
+        return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/__init__.py
@@ -6,8 +6,6 @@ from .eliminate_redundant_transposes import *
 from .fused_moe import *
 from .fusion import *
 from .kvcache import *
-from .quantization import *
-from .quantize_moe import *
 from .rms_norm import *
 from .rope import *
 from .sharding import *

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -32,8 +32,6 @@ from .library import (
     match_rope_layout,
     match_rope_pattern,
     optimize_rope,
-    quantize,
-    quantize_moe,
     resize_kv_cache,
     sharding_transform_executor,
     update_in_out_nodes,
@@ -70,9 +68,6 @@ class InferenceOptimizer:
         ############################################################################################
         # RUN PATTERN MATCHER TRANSFORMATIONS TO STANDARDIZE GRAPH REPRESENTATION
         ############################################################################################
-        # quantization
-        quantize(egm, self.factory.get_quant_config())
-        quantize_moe(egm, self.factory.get_quant_config())
 
         # Match MoE pattern
         match_moe_pattern(egm)

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_graph_test_helpers.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_graph_test_helpers.py
@@ -10,15 +10,32 @@ from torch.fx import GraphModule
 
 from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import SequenceInfo
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.factory import ModelFactory
 from tensorrt_llm._torch.auto_deploy.transformations.library.sharding import ShardingTransformInfo
 
 
-class FakeFactory:
-    def __init__(self, model: nn.Module):
-        self.model = model
+class FakeFactory(ModelFactory):
+    """Dummy factory to pass cache_config for testing."""
 
-    def build_model(self, device: str) -> nn.Module:
-        return self.model.to(device=device)
+    def __init__(self, model=None, cache_config=None, quant_config=None):
+        self._model = model
+        self.cache_config = cache_config
+        self.quant_config = quant_config
+
+    def build_model(self, device: str):
+        return self._model.to(device=device) if self._model else None
+
+    def _build_model(self, device: str):
+        return
+
+    def _load_checkpoint(self, model, device):
+        return
+
+    def get_cache_config(self):
+        return self.cache_config
+
+    def get_quant_config(self):
+        return self.quant_config
 
 
 class SequenceEmbeddingInfo(SequenceInfo):

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
@@ -2,15 +2,12 @@ import pytest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from _graph_test_helpers import run_test
+from _graph_test_helpers import run_test_transformed_gm
 from _model_test_utils import MoEOpModel
 from _torch_test_utils import fp4_compatible, fp8_compatible, trtllm_ops_available
 
-import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
-from tensorrt_llm._torch.auto_deploy.transformations.library.fused_moe import (
-    fuse_moe,
-    match_moe_pattern,
-)
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import fp4_global_scale
 
@@ -301,11 +298,20 @@ def test_moe_matching(quant_type, expected_op, atol, rtol):
             model.block_sparse_moe.gate = model.block_sparse_moe.gate.to(dtype=torch.bfloat16)
 
         x = model.get_input(device=device)
+        gm = torch_export_to_gm(model, args=(x,), clone=True)
+        gm_transformed = InferenceOptimizer(
+            None,
+            {
+                "match_moe_pattern": {
+                    "stage": "pattern_matcher",
+                },
+            },
+        )(None, gm)
 
-        _ = run_test(
+        run_test_transformed_gm(
             model,
             x,
-            match_moe_pattern,
+            gm_transformed,
             lambda gm: any(is_op(n, expected_op) for n in gm.graph.nodes),
             lambda num: num,
             atol=atol,
@@ -319,11 +325,20 @@ def test_moe_fusion():
     device = "cuda"
     model = MoEOpModel().to(device=device, dtype=torch.bfloat16)
     x = model.get_input(device=device, dtype=torch.bfloat16)
+    gm = torch_export_to_gm(model, args=(x,), clone=True)
+    gm_transformed = InferenceOptimizer(
+        None,
+        {
+            "fuse_moe": {
+                "stage": "post_load_fusion",
+            },
+        },
+    )(None, gm)
 
-    fused_gm_transformed = run_test(
+    run_test_transformed_gm(
         model,
         x,
-        fuse_moe,
+        gm_transformed,
         lambda gm: any(
             is_op(
                 n, {torch.ops.auto_deploy.torch_moe_fused, torch.ops.auto_deploy.trtllm_moe_fused}
@@ -339,7 +354,7 @@ def test_moe_fusion():
 
     # expert weights are fused and stacked in fusion
     num_param_nodes = len(list(model.named_parameters()))
-    num_param_nodes_fused = len(list(fused_gm_transformed.named_parameters()))
+    num_param_nodes_fused = len(list(gm_transformed.named_parameters()))
     assert (
         num_param_nodes_fused < num_param_nodes
     ), f"""number of parameter nodes after fusion {num_param_nodes_fused} <

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quantization.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quantization.py
@@ -4,19 +4,36 @@ Tests for basic graph sharding.
 
 import pytest
 import torch
-from _graph_test_helpers import run_test
+from _graph_test_helpers import run_test_transformed_gm
 from _model_test_utils import MLP, BMMDynamicModel, BMMModel
 from _torch_test_utils import fp4_compatible, fp8_compatible
 
 from tensorrt_llm._torch.auto_deploy.custom_ops.quant import QUANT_OPS
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
-from tensorrt_llm._torch.auto_deploy.transformations.library import quantize
+from tensorrt_llm._torch.auto_deploy.models.factory import ModelFactory
+from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import fp8_scale
 
 
 def check_quantized(gm):
     return any(is_op(n, QUANT_OPS) for n in gm.graph.nodes)
+
+
+class DummyFactory(ModelFactory):
+    """Dummy factory to pass quant_config for testing."""
+
+    def __init__(self, quant_config):
+        self.quant_config = quant_config
+
+    def _build_model(self, device: str):
+        return
+
+    def _load_checkpoint(self, model, device):
+        return
+
+    def get_quant_config(self):
+        return self.quant_config
 
 
 @pytest.mark.parametrize(
@@ -39,7 +56,7 @@ def check_quantized(gm):
     ],
 )
 def test_quantization(quant_config, atol, rtol, num_p_og):
-    pytest.skip("https://nvbugspro.nvidia.com/bug/5170222")
+    # pytest.skip("https://nvbugspro.nvidia.com/bug/5170222")
     model = MLP(32, 64, 32).to(torch.float16).to("cuda")
     x = torch.randn(3, 32, dtype=torch.float16).to("cuda")
 
@@ -51,11 +68,22 @@ def test_quantization(quant_config, atol, rtol, num_p_og):
         model.linear2.register_buffer(
             "input_scale", torch.tensor([1.0], device=model.linear2.weight.device)
         )
+    # set up sequence+cache objects
+    gm = torch_export_to_gm(model, args=(x,), clone=True)
+    gm_transformed = InferenceOptimizer(
+        DummyFactory(quant_config),
+        {
+            "quantize": {
+                "stage": "pattern_matcher",
+            },
+        },
+    )(None, gm)
+    gm_transformed.to("cuda")
 
-    gm_transformed = run_test(
+    run_test_transformed_gm(
         model,
         x,
-        quantize,
+        gm_transformed,
         check_quantized,
         num_p_og,
         atol,
@@ -122,10 +150,22 @@ def test_bmm_quantization(quant_config, atol, rtol, num_p_og, model_class):
             model.register_buffer("bmm_dynamic_input_scale", fp8_scale(x))
             model.register_buffer("bmm_dynamic_weight_scale", fp8_scale(dummy_weight))
 
-    gm_transformed = run_test(
+    # set up sequence+cache objects
+    gm = torch_export_to_gm(model, args=(x,), clone=True)
+    gm_transformed = InferenceOptimizer(
+        DummyFactory(quant_config),
+        {
+            "quantize": {
+                "stage": "pattern_matcher",
+            },
+        },
+    )(None, gm)
+    gm_transformed.to("cuda")
+
+    run_test_transformed_gm(
         model,
         x,
-        quantize,
+        gm_transformed,
         check_quantized,
         num_p_og,
         atol,


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

[JIRA ticket/NVBugs ID/GitHub issue][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR to support a new feature about cache manager for JIRA ticket TRTLLM-1000, it would be like:

[TRTLLM-1000][feat] Support a new feature about cache manager

Or I have a PR to fix a Llama3 accuracy issue:

[https://nvbugs/1234567][fix] Fix Llama3 accuracy issue
-->

## Description
#98 
<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

- Trt-bench:  
with modification, tp=1:
```
```

target branch, tp1=:
```
Request Throughput (req/sec):                     39.2947
Total Output Throughput (tokens/sec):             5029.7223
Total Token Throughput (tokens/sec):              10059.4446
Total Latency (ms):                               25448.7211
Average request latency (ms):                     19921.6154
Per User Output Throughput [w/ ctx] (tps/user):   6.9288
Per GPU Output Throughput (tps/gpu):              5029.7223
```
with modification, tp=2:
```
```
target branch, tp=2:
```
Request Throughput (req/sec):                     26.2887
Total Output Throughput (tokens/sec):             3364.9543
Total Token Throughput (tokens/sec):              6729.9085
Total Latency (ms):                               38039.1502
Average request latency (ms):                     29636.2802
Per User Output Throughput [w/ ctx] (tps/user):   4.6821
Per GPU Output Throughput (tps/gpu):              1682.4771
```
<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
