### PR TITLE
Move attention transforms to new inference optimizer

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -23,3 +23,11 @@ transforms:
     stage: pattern_matcher
   quantize_moe:
     stage: pattern_matcher
+  match_repeat_kv:
+    stage: pattern_matcher
+  match_eager_attention:
+    stage: pattern_matcher
+  match_grouped_attention:
+    stage: pattern_matcher
+  match_attention_layout:
+    stage: pattern_matcher

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
@@ -1,17 +1,21 @@
-"""Pattern matching for detecting eager and grouped attention pattern from Huggingface models."""
+"""Pattern matching for detecting repeat_kv pattern from Huggingface models."""
 
 from contextlib import nullcontext
-from typing import Any, Callable, Dict, List, Type
+from typing import Any, Callable, Dict, List, Tuple, Type
 
 import torch
 import torch.nn.functional as F
+from pydantic import Field
 from torch.fx import GraphModule
 
 from ...custom_ops.attention_interface import AttentionDescriptor
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface
+from ...transformations._graph import canonicalize_graph, lift_to_meta
 from ...utils.logger import ad_logger
 from ...utils.node_utils import is_op
 from ...utils.pattern_matcher import ADPatternMatcherPass, register_ad_pattern
-from .._graph import canonicalize_graph, lift_to_meta
+from ..interface import BaseTransform, TransformConfig, TransformInfo, TransformRegistry
 
 
 def _apply_pattern(
@@ -19,7 +23,7 @@ def _apply_pattern(
     pattern_name: str,
     register_fn: Callable[[ADPatternMatcherPass], None],
     shape_prop: bool = False,
-) -> None:
+) -> int:
     """Utility to register and apply a pattern."""
     patterns = ADPatternMatcherPass()
     register_fn(patterns)
@@ -28,100 +32,7 @@ def _apply_pattern(
     if num_matches > 0:
         with lift_to_meta(gm) if shape_prop else nullcontext():
             canonicalize_graph(gm, shape_prop=shape_prop)
-    ad_logger.info(f"Found and matched {num_matches} {pattern_name} pattern(s)")
-
-
-def match_repeat_kv(gm: GraphModule) -> None:
-    """
-    Match and replace the repeat_kv pattern with torch.ops.auto_deploy.torch_attention_repeat_kv.
-    """
-
-    def register_repeat_kv(patterns: ADPatternMatcherPass):
-        dummy_args = [
-            torch.randn(8, 8, 16, 64, device="cuda", dtype=torch.float16),
-            7,
-        ]
-        register_ad_pattern(
-            search_fn=_repeat_kv_pattern,
-            replace_fn=_repeat_kv_repl,
-            patterns=patterns,
-            dummy_args=dummy_args,
-            op_ignore_types={
-                torch.ops.aten.reshape.default: (int,),
-                torch.ops.aten.expand.default: (int,),
-            },
-            scalar_workaround={"n_rep": dummy_args[1]},
-        )
-
-    _apply_pattern(gm, "Repeat KV", register_repeat_kv, shape_prop=True)
-
-
-def match_eager_attention(gm: GraphModule) -> None:
-    """
-    Match and replace the eager attention pattern with torch.ops.auto_deploy.torch_attention_sdpa.
-    """
-
-    def register_eager_attention(patterns: ADPatternMatcherPass):
-        for pattern_config in _get_sfdp_patterns():
-            register_ad_pattern(**pattern_config, patterns=patterns)
-
-    _apply_pattern(gm, "Eager Attention", register_eager_attention)
-
-
-def match_grouped_attention(gm: GraphModule) -> None:
-    """
-    Match and replace the grouped attention pattern with
-    torch.ops.auto_deploy.torch_attention_grouped_sdpa.
-    """
-
-    def register_grouped_attention(patterns: ADPatternMatcherPass):
-        q = torch.randn(8, 8, 16, 64, device="cuda", dtype=torch.float16)
-        k1 = torch.randn(8, 1, 16, 64, device="cuda", dtype=torch.float16)
-        v1 = torch.randn(8, 1, 16, 64, device="cuda", dtype=torch.float16)
-        attn_mask = torch.randn(8, 1, 1, 16, device="cuda", dtype=torch.float16)
-        dropout = 0.12345
-        scale = 0.56789
-        n_rep = 7
-
-        dummy_args_1 = [q, k1, v1, n_rep, attn_mask, dropout, scale]
-        dummy_args_2 = [q, k1, v1, attn_mask, dropout, scale]
-
-        register_ad_pattern(
-            search_fn=_grouped_attn_pattern_1,
-            replace_fn=_grouped_attn_replacement_1,
-            patterns=patterns,
-            dummy_args=dummy_args_1,
-            scalar_workaround={"scale": scale, "dropout_p": dropout, "n_rep": n_rep},
-        )
-        register_ad_pattern(
-            search_fn=_grouped_attn_pattern_2,
-            replace_fn=_grouped_attn_replacement_2,
-            patterns=patterns,
-            dummy_args=dummy_args_2,
-            scalar_workaround={
-                "scale": scale,
-                "dropout_p": dropout,
-            },
-        )
-        register_ad_pattern(
-            search_fn=_grouped_attn_pattern_3,
-            replace_fn=_grouped_attn_replacement_3,
-            patterns=patterns,
-            dummy_args=dummy_args_1,
-            scalar_workaround={"scale": scale, "dropout_p": dropout, "n_rep": n_rep},
-        )
-        register_ad_pattern(
-            search_fn=_grouped_attn_pattern_4,
-            replace_fn=_grouped_attn_replacement_4,
-            patterns=patterns,
-            dummy_args=dummy_args_2,
-            scalar_workaround={
-                "scale": scale,
-                "dropout_p": dropout,
-            },
-        )
-
-    _apply_pattern(gm, "Grouped Attention", register_grouped_attention)
+    return num_matches
 
 
 def _repeat_kv_pattern(hidden_states, n_rep) -> torch.Tensor:
@@ -414,7 +325,146 @@ def _grouped_attn_replacement_4(q, k, v, attn_mask, dropout_p, scale):
     )
 
 
-def match_attention_layout(gm: GraphModule, attention_op: Type[AttentionDescriptor]) -> None:
+@TransformRegistry.register("match_repeat_kv")
+class MatchRepeatKV(BaseTransform):
+    """
+    Match and replace the repeat_kv pattern with torch.ops.auto_deploy.torch_attention_repeat_kv.
+    """
+
+    def _apply(
+        self, gm: GraphModule, cm: CachedSequenceInterface, factory: ModelFactory
+    ) -> Tuple[GraphModule, TransformInfo]:
+        def register_repeat_kv(patterns: ADPatternMatcherPass):
+            dummy_args = [
+                torch.randn(8, 8, 16, 64, device="cuda", dtype=torch.float16),
+                7,
+            ]
+            register_ad_pattern(
+                search_fn=_repeat_kv_pattern,
+                replace_fn=_repeat_kv_repl,
+                patterns=patterns,
+                dummy_args=dummy_args,
+                op_ignore_types={
+                    torch.ops.aten.reshape.default: (int,),
+                    torch.ops.aten.expand.default: (int,),
+                },
+                scalar_workaround={"n_rep": dummy_args[1]},
+            )
+
+        num_kv_patterns = _apply_pattern(gm, "Repeat KV", register_repeat_kv, shape_prop=True)
+
+        info = TransformInfo(
+            skipped=False,
+            num_matches=num_kv_patterns,
+            is_clean=True,
+            has_valid_shapes=True,
+        )
+
+        return gm, info
+
+
+@TransformRegistry.register("match_eager_attention")
+class MatchEagerAttention(BaseTransform):
+    """
+    Match and replace the eager attention pattern with torch.ops.auto_deploy.torch_attention_sdpa.
+    """
+
+    def _apply(
+        self, gm: GraphModule, cm: CachedSequenceInterface, factory: ModelFactory
+    ) -> Tuple[GraphModule, TransformInfo]:
+        def register_eager_attention(patterns: ADPatternMatcherPass):
+            for pattern_config in _get_sfdp_patterns():
+                register_ad_pattern(**pattern_config, patterns=patterns)
+
+        num_eager_patterns = _apply_pattern(gm, "Eager Attention", register_eager_attention)
+
+        info = TransformInfo(
+            skipped=False,
+            num_matches=num_eager_patterns,
+            is_clean=True,
+            has_valid_shapes=False,
+        )
+
+        return gm, info
+
+
+@TransformRegistry.register("match_grouped_attention")
+class MatchGroupedAttention(BaseTransform):
+    """
+    Match and replace the grouped attention pattern with
+    torch.ops.auto_deploy.torch_attention_grouped_sdpa.
+    """
+
+    def _apply(
+        self, gm: GraphModule, cm: CachedSequenceInterface, factory: ModelFactory
+    ) -> Tuple[GraphModule, TransformInfo]:
+        def register_grouped_attention(patterns: ADPatternMatcherPass):
+            q = torch.randn(8, 8, 16, 64, device="cuda", dtype=torch.float16)
+            k1 = torch.randn(8, 1, 16, 64, device="cuda", dtype=torch.float16)
+            v1 = torch.randn(8, 1, 16, 64, device="cuda", dtype=torch.float16)
+            attn_mask = torch.randn(8, 1, 1, 16, device="cuda", dtype=torch.float16)
+            dropout = 0.12345
+            scale = 0.56789
+            n_rep = 7
+
+            dummy_args_1 = [q, k1, v1, n_rep, attn_mask, dropout, scale]
+            dummy_args_2 = [q, k1, v1, attn_mask, dropout, scale]
+
+            register_ad_pattern(
+                search_fn=_grouped_attn_pattern_1,
+                replace_fn=_grouped_attn_replacement_1,
+                patterns=patterns,
+                dummy_args=dummy_args_1,
+                scalar_workaround={"scale": scale, "dropout_p": dropout, "n_rep": n_rep},
+            )
+            register_ad_pattern(
+                search_fn=_grouped_attn_pattern_2,
+                replace_fn=_grouped_attn_replacement_2,
+                patterns=patterns,
+                dummy_args=dummy_args_2,
+                scalar_workaround={
+                    "scale": scale,
+                    "dropout_p": dropout,
+                },
+            )
+            register_ad_pattern(
+                search_fn=_grouped_attn_pattern_3,
+                replace_fn=_grouped_attn_replacement_3,
+                patterns=patterns,
+                dummy_args=dummy_args_1,
+                scalar_workaround={"scale": scale, "dropout_p": dropout, "n_rep": n_rep},
+            )
+            register_ad_pattern(
+                search_fn=_grouped_attn_pattern_4,
+                replace_fn=_grouped_attn_replacement_4,
+                patterns=patterns,
+                dummy_args=dummy_args_2,
+                scalar_workaround={
+                    "scale": scale,
+                    "dropout_p": dropout,
+                },
+            )
+
+        num_grouped_patterns = _apply_pattern(gm, "Grouped Attention", register_grouped_attention)
+
+        info = TransformInfo(
+            skipped=False,
+            num_matches=num_grouped_patterns,
+            is_clean=True,
+            has_valid_shapes=False,
+        )
+
+        return gm, info
+
+
+class MatchAttentionLayoutConfig(TransformConfig):
+    """Configuration for the insert cached attention transform."""
+
+    attention_op: Type[AttentionDescriptor] = Field(description="The attention descriptor to use.")
+
+
+@TransformRegistry.register("match_attention_layout")
+class MatchAttentionLayout(BaseTransform):
     """
     Match and transform attention operations to match the layout expected by the attention backend.
 
@@ -424,81 +474,93 @@ def match_attention_layout(gm: GraphModule, attention_op: Type[AttentionDescript
     If the backend expects 'bsnd' layout (batch, seq_len, num_heads, head_dim), we insert
     appropriate transposes before and after SDPA operations and replace them with bsnd_grouped_sdpa.
     """
-    # Get attention layout from attention_op
-    attention_layout = attention_op.get_attention_layout()
 
-    # List of SDPA operations to look for
-    sdpa_ops = {
-        torch.ops.auto_deploy.torch_attention_sdpa,
-        torch.ops.auto_deploy.torch_attention_grouped_sdpa,
-    }
+    config: MatchAttentionLayoutConfig
 
-    graph = gm.graph
-    num_bsnd_patterns = 0
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return MatchAttentionLayoutConfig
 
-    # Look for SDPA operations
-    for sdpa_node in list(graph.nodes):
-        if sdpa_node.op != "call_function" or not is_op(sdpa_node, sdpa_ops):
-            continue
+    def _apply(
+        self, gm: GraphModule, cm: CachedSequenceInterface, factory: ModelFactory
+    ) -> Tuple[GraphModule, TransformInfo]:
+        # Get attention layout from attention_op
+        attention_layout = self.config.attention_op.get_attention_layout()
 
-        ad_logger.debug(f"Found SDPA node to transform for bsnd layout: {sdpa_node}")
+        # List of SDPA operations to look for
+        sdpa_ops = {
+            torch.ops.auto_deploy.torch_attention_sdpa,
+            torch.ops.auto_deploy.torch_attention_grouped_sdpa,
+        }
 
-        # Extract q, k, v inputs
-        q, k, v = sdpa_node.args[:3]
+        graph = gm.graph
+        num_bsnd_patterns = 0
 
-        # Check if we need to transpose the inputs
-        if attention_layout == "bsnd":
-            # Add transposes before the node (from bnsd to bsnd)
+        # Look for SDPA operations
+        for sdpa_node in list(graph.nodes):
+            if sdpa_node.op != "call_function" or not is_op(sdpa_node, sdpa_ops):
+                continue
+
+            ad_logger.debug(f"Found SDPA node to transform for bsnd layout: {sdpa_node}")
+
+            # Extract q, k, v inputs
+            q, k, v = sdpa_node.args[:3]
+
+            # Check if we need to transpose the inputs
+            if attention_layout == "bsnd":
+                # Add transposes before the node (from bnsd to bsnd)
+                with graph.inserting_before(sdpa_node):
+                    q_updated = graph.call_function(torch.ops.aten.transpose.int, args=(q, 1, 2))
+                    k_updated = graph.call_function(torch.ops.aten.transpose.int, args=(k, 1, 2))
+                    v_updated = graph.call_function(torch.ops.aten.transpose.int, args=(v, 1, 2))
+
+                # Preserve fake tensor in meta["val"] for the transposed inputs
+                q_updated.meta["val"] = q.meta["val"].transpose(1, 2)
+                k_updated.meta["val"] = k.meta["val"].transpose(1, 2)
+                v_updated.meta["val"] = v.meta["val"].transpose(1, 2)
+            elif attention_layout == "bnsd":
+                # we don't need to do anything...
+                q_updated = q
+                k_updated = k
+                v_updated = v
+            else:
+                raise ValueError(f"Unsupported attention layout: {attention_layout}")
+
+            # Create bsnd_grouped_sdpa node with the same args as the original node
+            # but using the transposed inputs
             with graph.inserting_before(sdpa_node):
-                q_updated = graph.call_function(torch.ops.aten.transpose.int, args=(q, 1, 2))
-                k_updated = graph.call_function(torch.ops.aten.transpose.int, args=(k, 1, 2))
-                v_updated = graph.call_function(torch.ops.aten.transpose.int, args=(v, 1, 2))
-
-            # Preserve fake tensor in meta["val"] for the transposed inputs
-            q_updated.meta["val"] = q.meta["val"].transpose(1, 2)
-            k_updated.meta["val"] = k.meta["val"].transpose(1, 2)
-            v_updated.meta["val"] = v.meta["val"].transpose(1, 2)
-        elif attention_layout == "bnsd":
-            # we don't need to do anything...
-            q_updated = q
-            k_updated = k
-            v_updated = v
-        else:
-            raise ValueError(f"Unsupported attention layout: {attention_layout}")
-
-        # Create bsnd_grouped_sdpa node with the same args as the original node
-        # but using the transposed inputs
-        with graph.inserting_before(sdpa_node):
-            source_sdpa_node = graph.call_function(
-                attention_op.get_source_attention_op(),
-                args=(q_updated, k_updated, v_updated) + sdpa_node.args[3:],
-                kwargs=sdpa_node.kwargs,
-            )
-
-        # Check if need to update the output node to match the layout
-        if attention_layout == "bsnd":
-            # Add transpose for the output (from bsnd back to bnsd)
-            with graph.inserting_after(source_sdpa_node):
-                output_updated = graph.call_function(
-                    torch.ops.aten.transpose.int, args=(source_sdpa_node, 1, 2)
+                source_sdpa_node = graph.call_function(
+                    self.config.attention_op.get_source_attention_op(),
+                    args=(q_updated, k_updated, v_updated) + sdpa_node.args[3:],
+                    kwargs=sdpa_node.kwargs,
                 )
 
-            # Preserve fake tensor in meta["val"] for the transposed inputs
-            source_sdpa_node.meta["val"] = sdpa_node.meta["val"].transpose(1, 2).contiguous()
-            output_updated.meta["val"] = source_sdpa_node.meta["val"].transpose(1, 2)
-        elif attention_layout == "bnsd":
-            output_updated = source_sdpa_node
-        else:
-            raise ValueError(f"Unsupported attention layout: {attention_layout}")
+            # Check if need to update the output node to match the layout
+            if attention_layout == "bsnd":
+                # Add transpose for the output (from bsnd back to bnsd)
+                with graph.inserting_after(source_sdpa_node):
+                    output_updated = graph.call_function(
+                        torch.ops.aten.transpose.int, args=(source_sdpa_node, 1, 2)
+                    )
 
-        # Replace the old node with the transposed output
-        sdpa_node.replace_all_uses_with(output_updated)
+                # Preserve fake tensor in meta["val"] for the transposed inputs
+                source_sdpa_node.meta["val"] = sdpa_node.meta["val"].transpose(1, 2).contiguous()
+                output_updated.meta["val"] = source_sdpa_node.meta["val"].transpose(1, 2)
+            elif attention_layout == "bnsd":
+                output_updated = source_sdpa_node
+            else:
+                raise ValueError(f"Unsupported attention layout: {attention_layout}")
 
-        num_bsnd_patterns += 1
+            # Replace the old node with the transposed output
+            sdpa_node.replace_all_uses_with(output_updated)
 
-    # Clean up the graph if we made any replacements
-    if num_bsnd_patterns:
-        canonicalize_graph(gm)
-        ad_logger.debug(f"Transformed graph for bsnd layout: {gm}")
+            num_bsnd_patterns += 1
 
-    ad_logger.info(f"Found and matched {num_bsnd_patterns} attention layouts")
+        info = TransformInfo(
+            skipped=False,
+            num_matches=num_bsnd_patterns,
+            is_clean=False,
+            has_valid_shapes=False,
+        )
+
+        return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
@@ -351,7 +351,10 @@ class MatchRepeatKV(BaseTransform):
                 scalar_workaround={"n_rep": dummy_args[1]},
             )
 
-        num_kv_patterns = _apply_pattern(gm, "Repeat KV", register_repeat_kv, shape_prop=True)
+        num_kv_patterns = _apply_pattern(gm, "Repeat KV", register_repeat_kv)
+
+        if num_kv_patterns > 0:
+            self.config.run_shape_prop = True
 
         info = TransformInfo(
             skipped=False,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
@@ -450,7 +450,7 @@ class MatchGroupedAttention(BaseTransform):
         info = TransformInfo(
             skipped=False,
             num_matches=num_grouped_patterns,
-            is_clean=True,
+            is_clean=False,
             has_valid_shapes=False,
         )
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
@@ -381,7 +381,7 @@ class MatchEagerAttention(BaseTransform):
         info = TransformInfo(
             skipped=False,
             num_matches=num_eager_patterns,
-            is_clean=True,
+            is_clean=False,
             has_valid_shapes=False,
         )
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
@@ -1,6 +1,5 @@
 """Pattern matching for detecting repeat_kv, eager, grouped attention patterns from Huggingface models."""
 
-from contextlib import nullcontext
 from typing import Any, Callable, Dict, List, Tuple, Type
 
 import torch
@@ -11,7 +10,6 @@ from torch.fx import GraphModule
 from ...custom_ops.attention_interface import AttentionDescriptor
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
-from ...transformations._graph import canonicalize_graph, lift_to_meta
 from ...utils.logger import ad_logger
 from ...utils.node_utils import is_op
 from ...utils.pattern_matcher import ADPatternMatcherPass, register_ad_pattern
@@ -22,16 +20,11 @@ def _apply_pattern(
     gm: GraphModule,
     pattern_name: str,
     register_fn: Callable[[ADPatternMatcherPass], None],
-    shape_prop: bool = False,
 ) -> int:
     """Utility to register and apply a pattern."""
     patterns = ADPatternMatcherPass()
     register_fn(patterns)
     num_matches = patterns.apply(gm.graph)
-
-    if num_matches > 0:
-        with lift_to_meta(gm) if shape_prop else nullcontext():
-            canonicalize_graph(gm, shape_prop=shape_prop)
     return num_matches
 
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
@@ -356,8 +356,8 @@ class MatchRepeatKV(BaseTransform):
         info = TransformInfo(
             skipped=False,
             num_matches=num_kv_patterns,
-            is_clean=True,
-            has_valid_shapes=True,
+            is_clean=False,
+            has_valid_shapes=False,
         )
 
         return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
@@ -1,4 +1,4 @@
-"""Pattern matching for detecting repeat_kv pattern from Huggingface models."""
+"""Pattern matching for detecting repeat_kv, eager, grouped attention patterns from Huggingface models."""
 
 from contextlib import nullcontext
 from typing import Any, Callable, Dict, List, Tuple, Type

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/__init__.py
@@ -1,6 +1,5 @@
 """A library of transformation passes."""
 
-from .attention import *
 from .collectives import *
 from .eliminate_redundant_transposes import *
 from .fused_moe import *

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -24,11 +24,7 @@ from .library import (
     fuse_collectives,
     fuse_rmsnorm,
     insert_cached_attention,
-    match_attention_layout,
-    match_eager_attention,
-    match_grouped_attention,
     match_moe_pattern,
-    match_repeat_kv,
     match_rope_layout,
     match_rope_pattern,
     optimize_rope,
@@ -60,6 +56,12 @@ class InferenceOptimizer:
         ############################################################################################
         # RUN MODULAR INFERENCE OPTIMIZER FOR ALREADY-MIGRATED TRANSFORMS
         ############################################################################################
+        # TODO (hg): default values that are not representable in YAML.
+        if "match_attention_layout" in self.ad_config.transforms:
+            self.ad_config.transforms[
+                "match_attention_layout"
+            ].attention_op = AttentionRegistry.get(self.ad_config.attn_backend)
+
         new_optimizer = ModularInferenceOptimizer(self.factory, self.ad_config.transforms)
         egm = new_optimizer(cm)
 
@@ -71,18 +73,6 @@ class InferenceOptimizer:
 
         # Match MoE pattern
         match_moe_pattern(egm)
-
-        # Match repeat_kv pattern
-        match_repeat_kv(egm)
-
-        # Match eager attention pattern
-        match_eager_attention(egm)
-
-        # Match grouped attention pattern
-        match_grouped_attention(egm)
-
-        # Match attention layout expected by our backend
-        match_attention_layout(egm, AttentionRegistry.get(self.ad_config.attn_backend))
 
         # Match rope
         match_rope_pattern(egm)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher.py
@@ -7,8 +7,8 @@ from torch.export import Dim
 from torch.fx import GraphModule
 from transformers.integrations.sdpa_attention import repeat_kv as hf_repeat_kv
 
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import AttentionDescriptor
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
-from tensorrt_llm._torch.auto_deploy.transformations.library.attention import AttentionDescriptor
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 
 torch.manual_seed(0)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher.py
@@ -8,12 +8,7 @@ from torch.fx import GraphModule
 from transformers.integrations.sdpa_attention import repeat_kv as hf_repeat_kv
 
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
-from tensorrt_llm._torch.auto_deploy.transformations.library.attention import (
-    match_attention_layout,
-    match_eager_attention,
-    match_grouped_attention,
-    match_repeat_kv,
-)
+from tensorrt_llm._torch.auto_deploy.transformations.library.attention import AttentionDescriptor
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 
 torch.manual_seed(0)
@@ -417,11 +412,13 @@ def _get_match_repeat_kv_optimizer() -> Callable:
         "cleanup_noop_slice": {
             "stage": "post_export",
         },
+        "match_repeat_kv": {
+            "stage": "pattern_matcher",
+        },
     }
 
     def _transform(gm: GraphModule) -> GraphModule:
         gm = InferenceOptimizer(None, config)(None, gm)
-        match_repeat_kv(gm)
         return gm
 
     return _transform
@@ -432,11 +429,13 @@ def _get_match_eager_attention_optimizer() -> Callable:
         "cleanup_noop_slice": {
             "stage": "post_export",
         },
+        "match_eager_attention": {
+            "stage": "pattern_matcher",
+        },
     }
 
     def _transform(gm: GraphModule) -> GraphModule:
         gm = InferenceOptimizer(None, config)(None, gm)
-        match_eager_attention(gm)
         return gm
 
     return _transform
@@ -447,11 +446,13 @@ def _get_match_grouped_attention_optimizer() -> Callable:
         "cleanup_noop_slice": {
             "stage": "post_export",
         },
+        "match_grouped_attention": {
+            "stage": "pattern_matcher",
+        },
     }
 
     def _transform(gm: GraphModule) -> GraphModule:
         gm = InferenceOptimizer(None, config)(None, gm)
-        match_grouped_attention(gm)
         return gm
 
     return _transform
@@ -1014,7 +1015,7 @@ class Llama3CausalAttentionModel(torch.nn.Module):
         return {0: Dim("batch_size", max=8), 1: Dim("seq_len", min=4, max=16)}
 
 
-class MockAttentionDescriptor:
+class MockAttentionDescriptor(AttentionDescriptor):
     """A mock class that mimics the AttentionDescriptor interface for testing."""
 
     layout: str = "bnsd"
@@ -1319,7 +1320,15 @@ def test_match_attention_layout(layout, model_config, has_mask):
     run_test(
         model,
         x,
-        lambda gm: match_attention_layout(gm, MockAttentionDescriptor),
+        lambda gm: InferenceOptimizer(
+            None,
+            {
+                "match_attention_layout": {
+                    "stage": "pattern_matcher",
+                    "attention_op": MockAttentionDescriptor,
+                },
+            },
+        )(None, gm),
         verify_matcher,
         lambda num_p_og: num_p_og,
         atol=1e-3,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
@@ -12,10 +12,10 @@ from torch.fx import GraphModule
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaModel
 
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import AttentionDescriptor
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
 from tensorrt_llm._torch.auto_deploy.transformations._graph import move_to_device
-from tensorrt_llm._torch.auto_deploy.transformations.library.attention import AttentionDescriptor
 
 torch.manual_seed(0)
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
@@ -13,18 +13,14 @@ from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaModel
 
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
 from tensorrt_llm._torch.auto_deploy.transformations._graph import move_to_device
-from tensorrt_llm._torch.auto_deploy.transformations.library import (
-    match_attention_layout,
-    match_eager_attention,
-    match_grouped_attention,
-    match_repeat_kv,
-)
+from tensorrt_llm._torch.auto_deploy.transformations.library.attention import AttentionDescriptor
 
 torch.manual_seed(0)
 
 
-class MockAttentionDescriptor:
+class MockAttentionDescriptor(AttentionDescriptor):
     """A mock class that mimics the AttentionDescriptor interface for testing."""
 
     layout: str = "bsnd"
@@ -49,10 +45,24 @@ class HFWrapper(nn.Module):
 
 
 def _joint_transform(gm: GraphModule) -> None:
-    match_repeat_kv(gm)
-    match_eager_attention(gm)
-    match_grouped_attention(gm)
-    match_attention_layout(gm, MockAttentionDescriptor())
+    gm = InferenceOptimizer(
+        None,
+        {
+            "match_repeat_kv": {
+                "stage": "pattern_matcher",
+            },
+            "match_eager_attention": {
+                "stage": "pattern_matcher",
+            },
+            "match_grouped_attention": {
+                "stage": "pattern_matcher",
+            },
+            "match_attention_layout": {
+                "stage": "pattern_matcher",
+                "attention_op": MockAttentionDescriptor,
+            },
+        },
+    )(None, gm)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

[JIRA ticket/NVBugs ID/GitHub issue][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR to support a new feature about cache manager for JIRA ticket TRTLLM-1000, it would be like:

[TRTLLM-1000][feat] Support a new feature about cache manager

Or I have a PR to fix a Llama3 accuracy issue:

[https://nvbugs/1234567][fix] Fix Llama3 accuracy issue
-->

## Description
#98 
<!--
Please explain the issue and the solution in short.
-->

## Test Coverage
- Unite tests passed;
- Trt-bench:  
with modification, tp=1:
```
Request Throughput (req/sec):                     39.0233
Total Output Throughput (tokens/sec):             4994.9836
Total Token Throughput (tokens/sec):              9989.9672
Total Latency (ms):                               25625.7099
Average request latency (ms):                     19997.5614
Per User Output Throughput [w/ ctx] (tps/user):   6.9144
Per GPU Output Throughput (tps/gpu):              4994.9836
```

target branch, tp1=:
```
Request Throughput (req/sec):                     38.3011
Total Output Throughput (tokens/sec):             4902.5367
Total Token Throughput (tokens/sec):              9805.0735
Total Latency (ms):                               26108.9324
Average request latency (ms):                     20536.3980
Per User Output Throughput [w/ ctx] (tps/user):   6.6992
Per GPU Output Throughput (tps/gpu):              4902.5367
```
with modification, tp=2:
```
Request Throughput (req/sec):                     26.5951
Total Output Throughput (tokens/sec):             3404.1689
Total Token Throughput (tokens/sec):              6808.3378
Total Latency (ms):                               37600.9547
Average request latency (ms):                     29403.6189
Per User Output Throughput [w/ ctx] (tps/user):   4.7042
Per GPU Output Throughput (tps/gpu):              1702.0844
```
target branch, tp=2:
```
Request Throughput (req/sec):                     26.2887
Total Output Throughput (tokens/sec):             3364.9543
Total Token Throughput (tokens/sec):              6729.9085
Total Latency (ms):                               38039.1502
Average request latency (ms):                     29636.2802
Per User Output Throughput [w/ ctx] (tps/user):   4.6821
Per GPU Output Throughput (tps/gpu):              1682.4771
```

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
