### PR TITLE
TRTLLM-6142: set torch recompile_limit based on cuda_graph_batch_sizes and refactored

### DIFF
--- a/examples/auto_deploy/build_and_run_ad.py
+++ b/examples/auto_deploy/build_and_run_ad.py
@@ -23,9 +23,6 @@ from tensorrt_llm._torch.auto_deploy.utils.logger import ad_logger
 from tensorrt_llm.llmapi.llm import RequestOutput
 from tensorrt_llm.sampling_params import SamplingParams
 
-# Global torch config, set the torch compile cache to fix up to llama 405B
-torch._dynamo.config.cache_size_limit = 20
-
 
 class PromptConfig(BaseModel):
     """Prompt configuration.

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_compile.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_compile.py
@@ -3,11 +3,19 @@
 import torch
 import torch.nn as nn
 
+from tensorrt_llm._torch.auto_deploy.utils.logger import ad_logger
+
 from ..compiler import BackendCompiler, BackendRegistry
 
 
 @BackendRegistry.register("torch-compile")
 class TorchCompileCompiler(BackendCompiler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Global torch config, set the torch compile cache to fix up to llama 405B
+        torch._dynamo.config.cache_size_limit = 20
+        ad_logger.info(f"Setting cache size limit to {torch._dynamo.config.cache_size_limit}")
+
     def compile(self) -> nn.Module:
         """Compile the model using torch.compile."""
         return torch.compile(self.gm, dynamic=True)

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_compile.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_compile.py
@@ -3,29 +3,11 @@
 import torch
 import torch.nn as nn
 
-from tensorrt_llm._torch.auto_deploy.utils.logger import ad_logger
-
 from ..compiler import BackendCompiler, BackendRegistry
 
 
 @BackendRegistry.register("torch-compile")
 class TorchCompileCompiler(BackendCompiler):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.cuda_graph_batch_sizes = self.compiler_kwargs.get("cuda_graph_batch_sizes")
-        if not self.cuda_graph_batch_sizes:
-            self.cuda_graph_batch_sizes = self._get_graph_batch_sizes(self.max_batch_size)
-        ad_logger.info(f"Setting cuda_graph_batch_sizes to {self.cuda_graph_batch_sizes}")
-
-        torch._dynamo.config.recompile_limit = max(
-            len(self.cuda_graph_batch_sizes), torch._dynamo.config.recompile_limit
-        )
-        ad_logger.info(f"Setting recompile limit to {torch._dynamo.config.recompile_limit}")
-
-        # Global torch config, set the torch compile cache to fix up to llama 405B
-        torch._dynamo.config.cache_size_limit = 20
-        ad_logger.info(f"Setting cache size limit to {torch._dynamo.config.cache_size_limit}")
-
     def compile(self) -> nn.Module:
         """Compile the model using torch.compile."""
         return torch.compile(self.gm, dynamic=True)

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_compile.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_compile.py
@@ -3,11 +3,29 @@
 import torch
 import torch.nn as nn
 
+from tensorrt_llm._torch.auto_deploy.utils.logger import ad_logger
+
 from ..compiler import BackendCompiler, BackendRegistry
 
 
 @BackendRegistry.register("torch-compile")
 class TorchCompileCompiler(BackendCompiler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cuda_graph_batch_sizes = self.compiler_kwargs.get("cuda_graph_batch_sizes")
+        if not self.cuda_graph_batch_sizes:
+            self.cuda_graph_batch_sizes = self._get_graph_batch_sizes(self.max_batch_size)
+        ad_logger.info(f"Setting cuda_graph_batch_sizes to {self.cuda_graph_batch_sizes}")
+
+        torch._dynamo.config.recompile_limit = max(
+            len(self.cuda_graph_batch_sizes), torch._dynamo.config.recompile_limit
+        )
+        ad_logger.info(f"Setting recompile limit to {torch._dynamo.config.recompile_limit}")
+
+        # Global torch config, set the torch compile cache to fix up to llama 405B
+        torch._dynamo.config.cache_size_limit = 20
+        ad_logger.info(f"Setting cache size limit to {torch._dynamo.config.cache_size_limit}")
+
     def compile(self) -> nn.Module:
         """Compile the model using torch.compile."""
         return torch.compile(self.gm, dynamic=True)

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_opt.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_opt.py
@@ -2,6 +2,8 @@
 
 import torch
 
+from tensorrt_llm._torch.auto_deploy.utils.logger import ad_logger
+
 from ..compiler import BackendRegistry
 from .torch_cudagraph import CapturedGraph, TorchCudagraphCompiler
 
@@ -9,6 +11,17 @@ from .torch_cudagraph import CapturedGraph, TorchCudagraphCompiler
 @BackendRegistry.register("torch-opt")
 class TorchOptCompiler(TorchCudagraphCompiler):
     """Compiler that uses both torch.compile and CUDA graphs."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        torch._dynamo.config.recompile_limit = max(
+            len(self.cuda_graph_batch_sizes), torch._dynamo.config.recompile_limit
+        )
+        ad_logger.info(f"Setting recompile limit to {torch._dynamo.config.recompile_limit}")
+
+        # Global torch config, set the torch compile cache to fix up to llama 405B
+        torch._dynamo.config.cache_size_limit = 20
+        ad_logger.info(f"Setting cache size limit to {torch._dynamo.config.cache_size_limit}")
 
     def _init_captured_graph(self, gm, in_spec, out_spec) -> CapturedGraph:
         gm = torch.compile(gm, dynamic=True)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_trtllm_bench.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_trtllm_bench.py
@@ -2,6 +2,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+import pytest
 import yaml
 from _model_test_utils import _hf_model_dir_or_hub_id
 from click.testing import CliRunner
@@ -64,7 +65,8 @@ def run_benchmark(model_name: str, dataset_path: str, temp_dir: str):
     assert result.exit_code == 0
 
 
-def test_trtllm_bench(llm_root):  # noqa: F811
+@pytest.mark.parametrize("compile_backend", ["torch-compile", "torch-opt", "torch-cudagraph"])
+def test_trtllm_bench(llm_root, compile_backend):  # noqa: F811
     model_name = _hf_model_dir_or_hub_id(
         f"{llm_models_root()}/TinyLlama-1.1B-Chat-v1.0", "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
     )
@@ -74,8 +76,9 @@ def test_trtllm_bench(llm_root):  # noqa: F811
             yaml.dump(
                 {
                     "model_kwargs": {"num_hidden_layers": 2},
-                    "cuda_graph_batch_sizes": [1, 2],
+                    "cuda_graph_batch_sizes": [1, 2, 4, 8, 16, 32, 64, 128],
                     "max_batch_size": 128,
+                    "compile_backend": compile_backend,
                 },
                 f,
             )


### PR DESCRIPTION
torch._dynamo.config.recompile_limit was not set, so the default value 8 was used, sometimes leading to eager execution.
This change sets it based on the len(cuda_graph_batch_sizes).
Additionally, moved the cuda_graph_batch_sizes calculation (if not set by the user) heuristic to TorchCudagraphCompiler,
have it be a mandatory param to CapturedGraph and removed max_batch_size param (because it is now inferred from cuda_graph_batch_sizes).
Also, moved cache_size_limit from build_and_run_ad.py to the torch-opt and torch-compile BEs.
Added all 3 backends to the test_trtllm_bench and extended the cuda_graph_batch_sizes because cuda graph asserts in small batch size and also it compares it to the input shape batch dim.

tested perf impact, perf is not impacted:

python3 $TENSORRT_LLM_SRC_DIR/benchmarks/cpp/prepare_dataset.py   --stdout  --tokenizer meta-llama/Meta-Llama-3.1-8B    token-norm-dist      --input-mea
n 128      --output-mean 128      --input-stdev 0     --output-stdev 0      --num-requests 256 > 128_128_256_256_dataset.txt

trtllm-bench -m meta-llama/Meta-Llama-3.1-8B throughput --extra_llm_api_options /lustre/fs1/portfolios/coreai/users/egeva/autodeploy-dashboard/extra.yaml --max_batch_size 256 --tp 1 --backend _autodeploy --dataset 128_128_256_256_dataset.txt

cat /lustre/fs1/portfolios/coreai/users/egeva/autodeploy-dashboard/extra.yaml:
compile_backend: torch-opt
free_mem_ratio: 0.8
runtime: trtllm
cuda_graph_batch_sizes: [1, 2, 4, 8, 16, 32, 64, 128, 256]
max_batch_size: 256
skip_loading_weights: true

Before this change: (git checkout b47abb48beb77108712f5c1c4f818102544d351f)
Request Throughput (req/sec):                     99.3473
Total Output Throughput (tokens/sec):             12716.4507
Total Token Throughput (tokens/sec):              25432.9014
Total Latency (ms):                               2576.8196
Average request latency (ms):                     2526.6432
Per User Output Throughput [w/ ctx] (tps/user):   50.6657
Per GPU Output Throughput (tps/gpu):              12716.4507


After this change:
Request Throughput (req/sec):                     100.6702
Total Output Throughput (tokens/sec):             12885.7876
Total Token Throughput (tokens/sec):              25771.5753
Total Latency (ms):                               2542.9567
Average request latency (ms):                     2491.5277
Per User Output Throughput [w/ ctx] (tps/user):   51.3799
Per GPU Output Throughput (tps/gpu):              12885.7876