### PR TITLE
Skip pattern matching in specified modules

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -384,6 +384,8 @@ class AutoModelForImageTextToTextFactory(AutoModelForCausalLMFactory):
         input_ids: torch.Tensor,
         position_ids: torch.Tensor,
         pixel_values: torch.Tensor,
+        # How to get this programmatically?
+        image_sizes: torch.Tensor,
     ):
         """A simple forward pass for the model to functionalize the args.
 
@@ -394,6 +396,7 @@ class AutoModelForImageTextToTextFactory(AutoModelForCausalLMFactory):
             input_ids=input_ids,
             position_ids=position_ids,
             pixel_values=pixel_values,
+            image_sizes=image_sizes,
         )
 
     def get_example_inputs(self) -> Dict[str, torch.Tensor]:
@@ -415,13 +418,13 @@ class AutoModelForImageTextToTextFactory(AutoModelForCausalLMFactory):
         batch_messages = [
             _prep_seq(
                 "Describe what you see in the two images and their differences.",
-                Image.new("RGB", (16, 16), color=(128, 128, 128)),
-                Image.new("RGB", (16, 16), color=(64, 64, 64)),
+                Image.new("RGB", (64, 64), color=(128, 128, 128)),
+                Image.new("RGB", (64, 64), color=(64, 64, 64)),
             ),
             _prep_seq(
                 "What are the main differences between these two images?",
-                Image.new("RGB", (16, 16), color=(255, 0, 0)),
-                Image.new("RGB", (16, 16), color=(0, 255, 0)),
+                Image.new("RGB", (64, 64), color=(255, 0, 0)),
+                Image.new("RGB", (64, 64), color=(0, 255, 0)),
             ),
         ]
 
@@ -437,8 +440,9 @@ class AutoModelForImageTextToTextFactory(AutoModelForCausalLMFactory):
         )
 
         return {
-            "input_ids": inputs["input_ids"],
-            "pixel_values": inputs["pixel_values"],
+            # "input_ids": inputs["input_ids"],
+            # "pixel_values": inputs["pixel_values"],
+            **inputs
         }
 
     def get_extra_inputs(self) -> Dict[str, Tuple[torch.Tensor, DynamicShapeCallback]]:
@@ -460,4 +464,9 @@ class AutoModelForImageTextToTextFactory(AutoModelForCausalLMFactory):
             }
 
         none_pixel_values = torch.zeros(0, 3, 336, 336)
-        return {"pixel_values": (none_pixel_values, _get_dynamic_shape)}
+        return {
+            "pixel_values": (none_pixel_values, _get_dynamic_shape),
+            # How to get this from the input processor? It seems there's no good way without
+            # running a dummy input through the processor.
+            "image_sizes": (torch.zeros(0, 2), None),
+        }

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/pixtral.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/pixtral.py
@@ -1,0 +1,220 @@
+"""A patch for the PixtralVisionModel to make it compatible with torch.export."""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers.models.mistral3.modeling_mistral3 import Mistral3PatchMerger
+from transformers.models.pixtral.modeling_pixtral import (
+    generate_block_attention_mask,
+    PixtralVisionModel,
+    position_ids_in_meshgrid,
+)
+
+from ...export.interface import BaseExportPatch, ExportPatchRegistry
+
+# @williamz notes:
+# 1. everything decorated by a `custom_op` must be type annotated.
+#    a. It must be one of the internally supported param types. As such, `self: PixtralVisionModel`
+#       is a no-go.
+#    As such, pretty much only free-standing functions with tensor inputs are supported - instance
+#    methods cannot be decorated.
+
+@torch.library.custom_op("auto_deploy::process_pixtral_patch_embeds", mutates_args={})
+def _process_patch_embeds(
+    patch_embeds: torch.Tensor,
+    image_sizes: torch.Tensor,
+    patch_size: int,
+    hidden_size: int,
+    max_width: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    patch_embeds_list = [
+        embed[..., : (size[0] // patch_size), : (size[1] // patch_size)]
+        for embed, size in zip(patch_embeds, image_sizes)
+    ]
+
+    # flatten to a single sequence
+    patch_embeds = torch.cat([p.flatten(1).T for p in patch_embeds_list], dim=0).unsqueeze(0)
+
+    position_ids = position_ids_in_meshgrid(patch_embeds_list, max_width=max_width)
+
+    return patch_embeds, position_ids
+
+
+@_process_patch_embeds.register_fake
+def _process_patch_embeds_meta(
+    patch_embeds: torch.Tensor,
+    image_sizes: torch.Tensor,
+    patch_size: int,
+    hidden_size: int,
+    max_widht: int,
+):
+    B = (image_sizes // patch_size).prod(dim=1).sum()
+    device = patch_embeds.device
+    return (
+        # Leading 1 = `unsqueeze(0)`.
+        # The symbolic tracing will actually not complain if `1` is missing - I guess because
+        # the number of elements in the underlying tensor is the same?
+        torch.empty(1, B, hidden_size, device=device),
+        torch.empty(hidden_size, device=device, dtype=torch.int64),
+    )
+
+
+def _pixtral_forward(
+    self: PixtralVisionModel,
+    pixel_values: torch.Tensor,
+    image_sizes: torch.Tensor | None,
+    output_hidden_states: bool | None = None,
+    output_attentions: bool | None = None,
+    return_dict: bool | None = None,
+    *args,
+    **kwargs,
+):
+    if image_sizes is None:
+        batch_size, _, height, width = pixel_values.shape
+        image_sizes = torch.tensor([(height, width)] * batch_size, device=pixel_values.device)
+
+    # pass images through initial convolution independently
+    patch_embeds = self.patch_conv(pixel_values)
+    patch_embeds, position_ids = torch.ops.auto_deploy.process_pixtral_patch_embeds(
+        patch_embeds=patch_embeds,
+        image_sizes=image_sizes,
+        patch_size=self.patch_size,
+        hidden_size=self.config.hidden_size,
+        max_width=self.config.image_size // self.config.patch_size,
+    )
+
+    patch_embeds = self.ln_pre(patch_embeds)
+
+    kwargs["position_ids"] = position_ids
+
+    position_embeddings = self.patch_positional_embedding(patch_embeds, position_ids)
+
+    if self.config._attn_implementation == "flash_attention_2":
+        # We only rely on position_ids when using flash_attention_2
+        attention_mask = None
+    else:
+        attention_mask = generate_block_attention_mask(
+            (image_sizes // self.config.patch_size).prod(dim=1),
+            patch_embeds,
+        )
+
+    return self.transformer(
+        patch_embeds,
+        attention_mask=attention_mask,
+        position_embeddings=position_embeddings,
+        output_hidden_states=output_hidden_states,
+        output_attentions=output_attentions,
+        return_dict=True,
+        **kwargs,
+    )
+
+
+def generate_block_attention_mask(num_ids_per_image, tensor):
+    dtype = tensor.dtype
+    device = tensor.device
+    seq_len = tensor.shape[1]
+    d_min = torch.finfo(dtype).min
+
+    idx = torch.arange(seq_len, device=device)
+    block_end_idx = num_ids_per_image.cumsum(-1)
+    block_start_idx = torch.cat(
+        [
+            num_ids_per_image.new_zeros((1,)),
+            num_ids_per_image[:-1],
+        ]
+    ).cumsum(-1)
+
+    # Build a mask where positions outside each [start, end) block are 1, inside are 0.
+    mask = torch.ones((seq_len, seq_len), device=device, dtype=dtype)
+    for start, end in zip(block_start_idx, block_end_idx):
+        block = (idx >= start) & (idx < end)
+        mask[block.unsqueeze(0) & block.unsqueeze(1)] = 0
+
+    return mask
+
+
+@torch.library.custom_op("auto_deploy::unfold_to_2d_grid", mutates_args={})
+def _unfold_to_2d_grid(
+    image_features: torch.Tensor,
+    image_sizes: torch.Tensor,
+    patch_size: int,
+    spatial_merge_size: int,
+) -> torch.Tensor:
+    image_sizes = [
+        (image_size[0] // patch_size, image_size[1] // patch_size) for image_size in image_sizes
+    ]
+
+    tokens_per_image = [h * w for h, w in image_sizes]
+    d = image_features.shape[-1]
+
+    permuted_tensor = []
+    for image_index, image_tokens in enumerate(image_features.split(tokens_per_image)):
+        # Reshape image_tokens into a 2D grid
+        h, w = image_sizes[image_index]
+        image_grid = image_tokens.view(h, w, d).permute(2, 0, 1).unsqueeze(0)
+        grid = torch.nn.functional.unfold(
+            image_grid, kernel_size=spatial_merge_size, stride=spatial_merge_size
+        )
+        grid = grid.view(d * spatial_merge_size**2, -1).t()
+        permuted_tensor.append(grid)
+
+    image_features = torch.cat(permuted_tensor, dim=0)
+
+
+@_unfold_to_2d_grid.register_fake
+def _unfold_to_2d_grid_meta(
+    image_features: torch.Tensor,
+    image_sizes: torch.Tensor,
+    patch_size: int,
+    spatial_merge_size: int,
+):
+    embedding_sizes = (image_sizes // patch_size).prod(dim=1)
+    spatial_factor = spatial_merge_size * spatial_merge_size
+    grid_sizes = embedding_sizes // spatial_factor
+    total_size = grid_sizes.sum()
+
+    return image_features.new_empty(total_size, image_features.shape[-1] * spatial_factor)
+
+
+def _patch_merger_forward(
+    self, image_features: torch.Tensor, image_sizes: torch.Tensor
+) -> torch.Tensor:
+    unfolded_features = torch.ops.auto_deploy.unfold_to_2d_grid(
+        image_features=image_features,
+        image_sizes=image_sizes,
+        patch_size=self.patch_size,
+        spatial_merge_size=self.spatial_merge_size,
+    )
+    image_features = self.merging_layer(unfolded_features)
+    return image_features
+
+
+@ExportPatchRegistry.register("hf_pixtral_vit")
+class PixtralVisionModelPatch(BaseExportPatch):
+    """Patch for `PixtralVisionModel`."""
+
+    def _apply_patch(self):
+        """Apply the PixtralVisionModel patch."""
+        # Store original forward method
+        self.original_values["PixtralVisionModel.forward"] = PixtralVisionModel.forward
+        self.original_values["Mistral3PatchMerger.forward"] = Mistral3PatchMerger.forward
+
+        # Apply patch by replacing the forward method
+        PixtralVisionModel._original_forward = PixtralVisionModel.forward  # type: ignore
+        PixtralVisionModel.forward = _pixtral_forward  # type: ignore
+
+        Mistral3PatchMerger._original_forward = Mistral3PatchMerger.forward
+        Mistral3PatchMerger.forward = _patch_merger_forward
+
+    def _revert_patch(self):
+        """Revert the PixtralVisionModel patch."""
+        # Restore original forward method.
+        PixtralVisionModel.forward = self.original_values["PixtralVisionModel.forward"]  # type: ignore
+        Mistral3PatchMerger.forward = self.original_values["Mistral3PatchMerger.forward"]
+
+        # Clean up the temporary attribute.
+        if hasattr(PixtralVisionModel, "_original_forward"):
+            delattr(PixtralVisionModel, "_original_forward")
+
+        if hasattr(Mistral3PatchMerger, "_original_forward"):
+            delattr(Mistral3PatchMerger, "_original_forward")

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/pixtral.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/pixtral.py
@@ -1,12 +1,10 @@
 """A patch for the PixtralVisionModel to make it compatible with torch.export."""
 
 import torch
-import torch.nn as nn
-import torch.nn.functional as F
 from transformers.models.mistral3.modeling_mistral3 import Mistral3PatchMerger
 from transformers.models.pixtral.modeling_pixtral import (
-    generate_block_attention_mask,
     PixtralVisionModel,
+    generate_block_attention_mask,
     position_ids_in_meshgrid,
 )
 
@@ -18,6 +16,7 @@ from ...export.interface import BaseExportPatch, ExportPatchRegistry
 #       is a no-go.
 #    As such, pretty much only free-standing functions with tensor inputs are supported - instance
 #    methods cannot be decorated.
+
 
 @torch.library.custom_op("auto_deploy::process_pixtral_patch_embeds", mutates_args={})
 def _process_patch_embeds(

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_gm.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_gm.py
@@ -71,7 +71,6 @@ class ExportToGM(BaseTransform):
                 strict=self.config.strict,
                 patch_list=self.config.patch_list,
             )
-
         # this is a clean graph by definition since it was just exported
         info = TransformInfo(skipped=False, num_matches=1, is_clean=True, has_valid_shapes=True)
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
@@ -28,10 +28,11 @@ def update_in_out_nodes(egm: GraphModule, cm: CachedSequenceInterface) -> None:
 
     # NOTE: for now, we wanna make sure we *only* return the final output and no hidden states.
     # Later on, we can revisit how to support returning hidden states.
-    assert len(output_nodes) == 1, "Expected exactly one output node!"
-    assert len(output_nodes[0].all_input_nodes) == 1, "Expected to only return final tensor output!"
-
     ad_logger.info(f"Found {len(input_nodes)} input nodes and {len(output_nodes)} output nodes")
+
+    assert len(output_nodes) == 1, "Expected exactly one output node!"
+    # the following assert feels too restrictive..
+    # assert len(output_nodes[0].all_input_nodes) == 1, "Expected to only return final tensor output!"
 
     # Activate and add extra argument nodes
     new_args = cm.info.switch_to_cached_attn_inputs()

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -422,3 +422,12 @@ def extract_op_args(node: Node, *arg_names):
         raise RuntimeError(f"Could not find a value for '{name}' on op {op}")
 
     return [_get(n) for n in arg_names]
+
+
+def is_node_in_module(node: Node, module_name: str) -> bool:
+    """Check if the node is in the given module."""
+    try:
+        nn_module_list = list(node.meta["nn_module_stack"].keys())[-1]
+        return module_name in nn_module_list
+    except:
+        return False

--- a/tensorrt_llm/_torch/auto_deploy/utils/pattern_matcher.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/pattern_matcher.py
@@ -32,6 +32,8 @@ from torch.fx import GraphModule
 
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 
+Match = torch._inductor.pattern_matcher.Match
+
 
 @contextlib.contextmanager
 def _patch_unsupported_input_tensor():
@@ -83,6 +85,7 @@ def _trace_to_gm(fn: Callable, args: Sequence[torch.Tensor]) -> GraphModule:
     Exports a function or Module into a GraphModule via torch_export_to_gm.
     """
     module = fn if isinstance(fn, torch.nn.Module) else _WrapperModule(fn)
+
     return torch_export_to_gm(module, tuple(args))
 
 


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

[JIRA ticket/NVBugs ID/GitHub issue][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR to support a new feature about cache manager for JIRA ticket TRTLLM-1000, it would be like:

[TRTLLM-1000][feat] Support a new feature about cache manager

Or I have a PR to fix a Llama3 accuracy issue:

[https://nvbugs/1234567][fix] Fix Llama3 accuracy issue
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
