### PR TITLE
Support Qwen 2.5 VL

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/__init__.py
@@ -7,6 +7,7 @@ from .flashinfer_rope import *
 from .linear import *
 from .mla import *
 from .quant import *
+from .qwen_ops import *
 from .rms_norm import *
 from .torch_attention import *
 from .torch_backend_attention import *

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/qwen_ops.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/qwen_ops.py
@@ -1,0 +1,273 @@
+"""Custom ops required for Qwen2.5-VL vision model export."""
+
+from typing import Tuple
+
+import torch
+
+
+@torch.library.custom_op(
+    "auto_deploy::qwen_vision_data_dependent_ops", mutates_args=(), device_types=["cuda", "cpu"]
+)
+def qwen_vision_data_dependent_ops(
+    grid_thw: torch.Tensor,
+    hidden_states: torch.Tensor,
+    spatial_merge_size: int,
+    window_size: int,
+    patch_size: int,
+    spatial_merge_unit: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Custom op that encapsulates all data-dependent operations for Qwen2.5-VL vision model.
+
+    Args:
+        grid_thw: Grid dimensions [num_images, 3] where each row is [t, h, w]
+        hidden_states: Hidden states after patch embedding
+        spatial_merge_size: Spatial merge size for the vision model
+        window_size: Window size for windowed attention
+        patch_size: Vision transformer patch size
+        spatial_merge_unit: Spatial merge unit
+
+    Returns:
+        processed_hidden_states: Hidden states after window indexing
+        pos_emb_cos: Cosine part of position embeddings
+        pos_emb_sin: Sine part of position embeddings
+        cu_window_seqlens: Cumulative window sequence lengths
+        cu_seqlens: Cumulative sequence lengths for full attention
+        reverse_indices: Indices to reverse the window ordering (for final step)
+    """
+    device = grid_thw.device
+
+    # === ROT_POS_EMB CALCULATION ===
+    pos_ids = []
+    for t, h, w in grid_thw:
+        hpos_ids = torch.arange(h).unsqueeze(1).expand(-1, w)
+        hpos_ids = hpos_ids.reshape(
+            h // spatial_merge_size,
+            spatial_merge_size,
+            w // spatial_merge_size,
+            spatial_merge_size,
+        )
+        hpos_ids = hpos_ids.permute(0, 2, 1, 3)
+        hpos_ids = hpos_ids.flatten()
+
+        wpos_ids = torch.arange(w).unsqueeze(0).expand(h, -1)
+        wpos_ids = wpos_ids.reshape(
+            h // spatial_merge_size,
+            spatial_merge_size,
+            w // spatial_merge_size,
+            spatial_merge_size,
+        )
+        wpos_ids = wpos_ids.permute(0, 2, 1, 3)
+        wpos_ids = wpos_ids.flatten()
+        pos_ids.append(torch.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1))
+
+    pos_ids = torch.cat(pos_ids, dim=0)
+    max_grid_size = grid_thw[:, 1:].max()
+
+    # Rotary embedding calculation (matching original implementation)
+    dim = 40  # head_dim // 2 for Qwen2.5-VL
+    theta = 10000.0
+    # Match original implementation exactly - no explicit device specification
+    inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float) / dim))
+    # Move to device after calculation to match the flow
+    inv_freq = inv_freq.to(device)
+    torch.save(inv_freq, "inv_freq_patched.pt")
+    seq = torch.arange(max_grid_size, device=device, dtype=torch.float)
+    freqs = torch.outer(seq, inv_freq)
+    rotary_pos_emb_full = freqs
+    rotary_pos_emb = rotary_pos_emb_full[pos_ids].flatten(1)
+
+    # === GET_WINDOW_INDEX CALCULATION ===
+    window_index = []
+    cu_window_seqlens = [0]
+    window_index_id = 0
+    vit_merger_window_size = window_size // spatial_merge_size // patch_size
+
+    for grid_t, grid_h, grid_w in grid_thw:
+        llm_grid_h, llm_grid_w = (
+            grid_h.item() // spatial_merge_size,
+            grid_w.item() // spatial_merge_size,
+        )
+        index = torch.arange(grid_t * llm_grid_h * llm_grid_w).reshape(
+            grid_t, llm_grid_h, llm_grid_w
+        )
+        pad_h = vit_merger_window_size - llm_grid_h % vit_merger_window_size
+        pad_w = vit_merger_window_size - llm_grid_w % vit_merger_window_size
+        num_windows_h = (llm_grid_h + pad_h) // vit_merger_window_size
+        num_windows_w = (llm_grid_w + pad_w) // vit_merger_window_size
+        index_padded = torch.nn.functional.pad(index, (0, pad_w, 0, pad_h), "constant", -100)
+        index_padded = index_padded.reshape(
+            grid_t,
+            num_windows_h,
+            vit_merger_window_size,
+            num_windows_w,
+            vit_merger_window_size,
+        )
+        index_padded = index_padded.permute(0, 1, 3, 2, 4).reshape(
+            grid_t,
+            num_windows_h * num_windows_w,
+            vit_merger_window_size,
+            vit_merger_window_size,
+        )
+        seqlens = (index_padded != -100).sum([2, 3]).reshape(-1)
+        index_padded = index_padded.reshape(-1)
+        index_new = index_padded[index_padded != -100]
+        window_index.append(index_new + window_index_id)
+        cu_seqlens_tmp = seqlens.cumsum(0) * spatial_merge_unit + cu_window_seqlens[-1]
+        cu_window_seqlens.extend(cu_seqlens_tmp.tolist())
+        window_index_id += (grid_t * llm_grid_h * llm_grid_w).item()
+
+    window_index = torch.cat(window_index, dim=0)
+    cu_window_seqlens = torch.tensor(
+        cu_window_seqlens,
+        device=hidden_states.device,
+        dtype=grid_thw.dtype if torch.jit.is_tracing() else torch.int32,
+    )
+    cu_window_seqlens = torch.unique_consecutive(cu_window_seqlens)
+
+    # === CU_SEQLENS CALCULATION ===
+    cu_seqlens = torch.repeat_interleave(grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]).cumsum(
+        dim=0,
+        dtype=grid_thw.dtype if torch.jit.is_tracing() else torch.int32,
+    )
+    cu_seqlens = torch.nn.functional.pad(cu_seqlens, (1, 0), value=0)
+
+    # === REVERSE_INDICES CALCULATION ===
+    reverse_indices = torch.argsort(window_index)
+
+    # === ADVANCED INDEXING OPERATIONS ===
+    # Process hidden_states with window indexing
+    seq_len, _ = hidden_states.size()
+    hidden_states = hidden_states.reshape(seq_len // spatial_merge_unit, spatial_merge_unit, -1)
+    hidden_states = hidden_states[window_index, :, :]  # ADVANCED INDEXING
+    hidden_states = hidden_states.reshape(seq_len, -1)
+
+    # Process rotary_pos_emb with window indexing
+    rotary_pos_emb = rotary_pos_emb.reshape(seq_len // spatial_merge_unit, spatial_merge_unit, -1)
+    rotary_pos_emb = rotary_pos_emb[window_index, :, :]  # ADVANCED INDEXING
+    rotary_pos_emb = rotary_pos_emb.reshape(seq_len, -1)
+    emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+
+    pos_emb_cos = emb.cos()
+    pos_emb_sin = emb.sin()
+
+    return hidden_states, pos_emb_cos, pos_emb_sin, cu_window_seqlens, cu_seqlens, reverse_indices
+
+
+@qwen_vision_data_dependent_ops.register_fake
+def qwen_vision_data_dependent_ops_fake(
+    grid_thw: torch.Tensor,
+    hidden_states: torch.Tensor,
+    spatial_merge_size: int,
+    window_size: int,
+    patch_size: int,
+    spatial_merge_unit: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Fake implementation for symbolic tracing.
+    Returns tensors with correct symbolic shapes but dummy values.
+    """
+    device = grid_thw.device
+    dtype = grid_thw.dtype
+
+    # Calculate total sequence length from hidden_states
+    seq_len = hidden_states.shape[0]
+
+    # Fake processed hidden_states: same shape as input
+    processed_hidden_states = torch.zeros_like(hidden_states)
+
+    # Fake position embeddings: separate cos and sin tensors with doubled embedding dim
+    emb_dim = 80  # head_dim for Qwen2.5-VL
+    pos_emb_cos = torch.zeros(seq_len, emb_dim, device=device, dtype=hidden_states.dtype)
+    pos_emb_sin = torch.zeros(seq_len, emb_dim, device=device, dtype=hidden_states.dtype)
+
+    # Fake cu_window_seqlens: varies based on windowing, but approximate
+    num_windows = (seq_len // spatial_merge_unit // 16) + 2  # rough estimate
+    cu_window_seqlens = torch.arange(num_windows + 1, device=device, dtype=dtype) * 16
+
+    # Fake cu_seqlens: [num_images + 1]
+    cu_seqlens = torch.cumsum(grid_thw[:, 1] * grid_thw[:, 2] * grid_thw[:, 0], dim=0)
+    cu_seqlens = torch.nn.functional.pad(cu_seqlens, (1, 0), value=0)
+    cu_seqlens = cu_seqlens.to(dtype=dtype)
+
+    # Fake reverse_indices: identity mapping for fake implementation
+    reverse_indices = torch.arange(seq_len, device=device, dtype=torch.long)
+
+    return (
+        processed_hidden_states,
+        pos_emb_cos,
+        pos_emb_sin,
+        cu_window_seqlens,
+        cu_seqlens,
+        reverse_indices,
+    )
+
+
+@torch.library.custom_op(
+    "auto_deploy::qwen_prepare_attention_mask", mutates_args=(), device_types=["cuda", "cpu"]
+)
+def qwen_prepare_attention_mask(
+    hidden_states: torch.Tensor, cu_seqlens: torch.Tensor, attn_implementation: str
+) -> torch.Tensor:
+    """
+    Custom op for _prepare_attention_mask to handle data-dependent operations.
+
+    Based on Qwen2_5_VisionTransformerPretrainedModel._prepare_attention_mask
+
+    Returns a special marker tensor (empty tensor) when attention_mask should be None.
+    """
+    # Flash Attention 2 doesn't need a 4D mask and relies on `cu_seqlens/max_seqlen`
+    if attn_implementation == "flash_attention_2":
+        # Return empty tensor as marker for None
+        return torch.empty(0, device=hidden_states.device, dtype=hidden_states.dtype)
+
+    seq_length = hidden_states.shape[0]
+    attention_mask = torch.full(
+        [1, 1, seq_length, seq_length],
+        torch.finfo(hidden_states.dtype).min,
+        device=hidden_states.device,
+        dtype=hidden_states.dtype,
+    )
+    for i in range(1, len(cu_seqlens)):
+        attention_mask[
+            ..., cu_seqlens[i - 1] : cu_seqlens[i], cu_seqlens[i - 1] : cu_seqlens[i]
+        ] = 0
+    return attention_mask
+
+
+@qwen_prepare_attention_mask.register_fake
+def qwen_prepare_attention_mask_fake(
+    hidden_states: torch.Tensor, cu_seqlens: torch.Tensor, attn_implementation: str
+) -> torch.Tensor:
+    """Fake implementation for symbolic tracing."""
+    if attn_implementation == "flash_attention_2":
+        # Return empty tensor as marker for None
+        return torch.empty(0, device=hidden_states.device, dtype=hidden_states.dtype)
+
+    seq_length = hidden_states.shape[0]
+    attention_mask = torch.zeros(
+        [1, 1, seq_length, seq_length],
+        device=hidden_states.device,
+        dtype=hidden_states.dtype,
+    )
+    return attention_mask
+
+
+@torch.library.custom_op(
+    "auto_deploy::qwen_reverse_indexing", mutates_args=(), device_types=["cuda", "cpu"]
+)
+def qwen_reverse_indexing(
+    hidden_states: torch.Tensor, reverse_indices: torch.Tensor
+) -> torch.Tensor:
+    """
+    Custom op for reverse indexing operation to handle advanced indexing with symbolic indices.
+    """
+    return hidden_states[reverse_indices, :]
+
+
+@qwen_reverse_indexing.register_fake
+def qwen_reverse_indexing_fake(
+    hidden_states: torch.Tensor, reverse_indices: torch.Tensor
+) -> torch.Tensor:
+    """Fake implementation for symbolic tracing."""
+    return torch.zeros_like(hidden_states)

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -489,7 +489,7 @@ class AutoModelForImageTextToTextFactory(AutoModelForCausalLMFactory):
                 14308, 1176
             ),  # Example shape for export (will be dynamic at runtime)
             "image_grid_thw": torch.tensor(
-                [[1, 98, 146]], dtype=torch.long
+                [[1, 98, 146], [1, 98, 146]], dtype=torch.long
             ),  # Example grid for export (will be dynamic at runtime)
         }
 
@@ -523,9 +523,9 @@ class AutoModelForImageTextToTextFactory(AutoModelForCausalLMFactory):
             }
 
         def image_grid_thw_dynamic_shape():
-            # TODO: add dynamic shape for image_grid_thw,
-            # the pytorch returned error when I change the first batch dim to dynamic
-            return {}
+            return {
+                0: Dim("_num_images", min=1, max=10),
+            }
 
         return {
             "pixel_values": (pixel_values_tensor, pixel_values_dynamic_shape),

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/qwen2_5_vl.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/qwen2_5_vl.py
@@ -1,0 +1,153 @@
+"""Patches for Qwen2.5-VL model to make it compatible with torch.export."""
+
+import torch
+
+from ...export.interface import BaseExportPatch, ExportPatchRegistry
+
+
+def _patched_vision_forward(self, hidden_states: torch.Tensor, grid_thw: torch.Tensor, **kwargs):
+    """
+    Patched forward method for Qwen2.5-VL vision transformer.
+
+    This patch moves ALL data-dependent operations into custom ops to make
+    the method fully compatible with torch.export's symbolic tracing.
+    """
+    # Original patch_embed processing (no data dependencies)
+    hidden_states = self.patch_embed(hidden_states)
+
+    # Use custom op to handle ALL data-dependent operations including advanced indexing
+    hidden_states, pos_emb_cos, pos_emb_sin, cu_window_seqlens, cu_seqlens, reverse_indices = (
+        torch.ops.auto_deploy.qwen_vision_data_dependent_ops(
+            grid_thw,
+            hidden_states,
+            self.spatial_merge_size,
+            self.window_size,
+            self.patch_size,
+            self.spatial_merge_unit,
+        )
+    )
+
+    # Create position_embeddings tuple from separate tensors
+    position_embeddings = (pos_emb_cos, pos_emb_sin)
+
+    # Process through attention blocks (using custom op for attention mask)
+    for layer_num, blk in enumerate(self.blocks):
+        if layer_num in self.fullatt_block_indexes:
+            cu_seqlens_now = cu_seqlens
+        else:
+            cu_seqlens_now = cu_window_seqlens
+
+        # Use custom op for _prepare_attention_mask (handles data-dependent operations)
+        attention_mask_tensor = torch.ops.auto_deploy.qwen_prepare_attention_mask(
+            hidden_states, cu_seqlens_now, self.config._attn_implementation
+        )
+
+        # Convert empty tensor marker back to None
+        attention_mask = None if attention_mask_tensor.numel() == 0 else attention_mask_tensor
+        hidden_states = blk(
+            hidden_states,
+            cu_seqlens=cu_seqlens_now,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+            **kwargs,
+        )
+    # Final merger (no data dependencies)
+    hidden_states = self.merger(hidden_states)
+
+    # Use custom op for reverse indexing (handles data-dependent operations)
+    hidden_states = torch.ops.auto_deploy.qwen_reverse_indexing(hidden_states, reverse_indices)
+
+    return hidden_states
+
+
+def _patched_rope_forward(self, x, position_ids):
+    """
+    Patched forward method for Qwen2_5_VLRotaryEmbedding to handle 'meta' device during torch.export.
+
+    This patch fixes the device_type issue when using torch.export where device becomes 'meta'.
+    """
+    # In contrast to other models, Qwen2_5_VL has different position ids for the grids
+    # So we expand the inv_freq to shape (3, ...)
+    inv_freq_expanded = (
+        self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1)
+    )
+    position_ids_expanded = position_ids[:, :, None, :].float()  # shape (3, bs, 1, positions)
+
+    # Fix device type handling for torch.export (where device can be 'meta')
+    device_type = (
+        x.device.type
+        if isinstance(x.device.type, str) and x.device.type not in ["mps", "meta"]
+        else "cpu"
+    )
+
+    with torch.autocast(device_type=device_type, enabled=False):  # Force float32
+        freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(2, 3)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos = emb.cos() * self.attention_scaling
+        sin = emb.sin() * self.attention_scaling
+
+    return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+def _patched_create_causal_mask(**kwargs):
+    """
+    Patched create_causal_mask function that returns None to avoid issues during model export/execution.
+
+    This is a temporary workaround for compatibility issues with create_causal_mask during
+    TensorRT-LLM model execution.
+    """
+    return None
+
+
+@ExportPatchRegistry.register("qwen2_5_vl_vision")
+class Qwen2_5_VLVisionPatch(BaseExportPatch):
+    """
+    Patch for Qwen2.5-VL model to make it compatible with torch.export.
+
+    This patch applies fixes for:
+    1. Vision transformer forward method (using custom ops for data-dependent operations)
+    2. Rotary embedding forward method (handling 'meta' device during export)
+    3. create_causal_mask function (returns None to avoid execution issues)
+    """
+
+    def _apply_patch(self):
+        import transformers.models.qwen2_5_vl.modeling_qwen2_5_vl as qwen_modeling
+        from transformers.masking_utils import create_causal_mask
+        from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
+            Qwen2_5_VisionTransformerPretrainedModel,
+            Qwen2_5_VLRotaryEmbedding,
+        )
+
+        # Store original methods
+        self.original_values["vision_forward"] = Qwen2_5_VisionTransformerPretrainedModel.forward
+        self.original_values["rope_forward"] = Qwen2_5_VLRotaryEmbedding.forward
+        self.original_values["create_causal_mask"] = create_causal_mask
+        self.original_values["qwen_create_causal_mask"] = qwen_modeling.create_causal_mask
+
+        # Apply patches
+        Qwen2_5_VisionTransformerPretrainedModel.forward = _patched_vision_forward
+        Qwen2_5_VLRotaryEmbedding.forward = _patched_rope_forward
+
+        # Patch the create_causal_mask function in both the masking_utils module
+        # and the locally imported reference in the qwen2_5_vl modeling module
+        import transformers.masking_utils
+
+        transformers.masking_utils.create_causal_mask = _patched_create_causal_mask
+        qwen_modeling.create_causal_mask = _patched_create_causal_mask
+
+    def _revert_patch(self):
+        import transformers.models.qwen2_5_vl.modeling_qwen2_5_vl as qwen_modeling
+        from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
+            Qwen2_5_VisionTransformerPretrainedModel,
+            Qwen2_5_VLRotaryEmbedding,
+        )
+
+        # Restore original methods
+        Qwen2_5_VisionTransformerPretrainedModel.forward = self.original_values["vision_forward"]
+        Qwen2_5_VLRotaryEmbedding.forward = self.original_values["rope_forward"]
+
+        # Restore original create_causal_mask function in both locations
+        import transformers.masking_utils
+
+        transformers.masking_utils.create_causal_mask = self.original_values["create_causal_mask"]
+        qwen_modeling.create_causal_mask = self.original_values["qwen_create_causal_mask"]

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/qwen2_5_vl.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/qwen2_5_vl.py
@@ -1,5 +1,7 @@
 """Patches for Qwen2.5-VL model to make it compatible with torch.export."""
 
+from typing import Optional
+
 import torch
 
 from ...export.interface import BaseExportPatch, ExportPatchRegistry
@@ -99,6 +101,118 @@ def _patched_create_causal_mask(**kwargs):
     return None
 
 
+def _patched_get_image_features_flat(
+    self, pixel_values: torch.FloatTensor, image_grid_thw: Optional[torch.LongTensor] = None
+):
+    """
+    WAR: Return flat image features directly; avoid Python list/split that specializes num_images.
+    """
+    pixel_values = pixel_values.type(self.visual.dtype)
+    image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
+    return image_embeds
+
+
+def _patched_model_forward_export_war(
+    self,
+    input_ids: torch.LongTensor = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[list[torch.FloatTensor]] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    use_cache: Optional[bool] = None,
+    output_attentions: Optional[bool] = None,
+    output_hidden_states: Optional[bool] = None,
+    return_dict: Optional[bool] = None,
+    pixel_values: Optional[torch.Tensor] = None,
+    pixel_values_videos: Optional[torch.FloatTensor] = None,
+    image_grid_thw: Optional[torch.LongTensor] = None,
+    video_grid_thw: Optional[torch.LongTensor] = None,
+    rope_deltas: Optional[torch.LongTensor] = None,
+    cache_position: Optional[torch.LongTensor] = None,
+    second_per_grid_ts: Optional[torch.Tensor] = None,
+    **kwargs,
+):
+    """
+    WAR forward: (a) do not call get_rope_index; synthesize tensor position_ids if None,
+    (b) consume flat image features directly (no split/cat).
+    """
+    from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import Qwen2_5_VLModelOutputWithPast
+    from transformers.utils import is_torchdynamo_compiling
+
+    output_attentions = (
+        output_attentions if output_attentions is not None else self.config.output_attentions
+    )
+    output_hidden_states = (
+        output_hidden_states
+        if output_hidden_states is not None
+        else self.config.output_hidden_states
+    )
+    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+    if inputs_embeds is None:
+        inputs_embeds = self.get_input_embeddings()(input_ids)
+        if pixel_values is not None:
+            image_embeds = self.get_image_features(pixel_values, image_grid_thw)
+            n_image_tokens = (input_ids == self.config.image_token_id).sum()
+            n_image_features = image_embeds.shape[0]
+            if not is_torchdynamo_compiling() and n_image_tokens != n_image_features:
+                raise ValueError(
+                    f"Image features and image tokens do not match tokens:{n_image_tokens}, features:{n_image_features}"
+                )
+            mask = input_ids == self.config.image_token_id
+            image_mask = mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
+            image_embeds = image_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+
+        if pixel_values_videos is not None:
+            # Keep videos flat as well
+            pixel_values_videos = pixel_values_videos.type(self.visual.dtype)
+            video_embeds = self.visual(pixel_values_videos, grid_thw=video_grid_thw)
+            n_video_tokens = (input_ids == self.config.video_token_id).sum()
+            n_video_features = video_embeds.shape[0]
+            if not is_torchdynamo_compiling() and n_video_tokens != n_video_features:
+                raise ValueError(
+                    f"Video features and video tokens do not match tokens:{n_video_tokens}, features:{n_video_features}"
+                )
+            mask = input_ids == self.config.video_token_id
+            video_mask = mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
+            video_embeds = video_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
+
+    # Bypass get_rope_index: synthesize simple tensor position_ids if None
+    if position_ids is None:
+        bsz, seqlen = inputs_embeds.shape[0], inputs_embeds.shape[1]
+        base = torch.arange(seqlen, device=inputs_embeds.device, dtype=inputs_embeds.dtype)
+        position_ids = base.view(1, 1, -1).expand(3, bsz, -1)
+        # keep rope_deltas as zeros per batch
+        self.rope_deltas = torch.zeros(
+            (bsz, 1), device=inputs_embeds.device, dtype=inputs_embeds.dtype
+        )
+
+    outputs = self.language_model(
+        input_ids=None,
+        position_ids=position_ids,
+        attention_mask=attention_mask,
+        past_key_values=past_key_values,
+        inputs_embeds=inputs_embeds,
+        use_cache=use_cache,
+        output_attentions=output_attentions,
+        output_hidden_states=output_hidden_states,
+        return_dict=True,
+        cache_position=cache_position,
+        **kwargs,
+    )
+
+    output = Qwen2_5_VLModelOutputWithPast(
+        last_hidden_state=outputs.last_hidden_state,
+        past_key_values=outputs.past_key_values,
+        hidden_states=outputs.hidden_states,
+        attentions=outputs.attentions,
+        rope_deltas=self.rope_deltas,
+    )
+    return output if return_dict else output.to_tuple()
+
+
 @ExportPatchRegistry.register("qwen2_5_vl_vision")
 class Qwen2_5_VLVisionPatch(BaseExportPatch):
     """
@@ -108,6 +222,7 @@ class Qwen2_5_VLVisionPatch(BaseExportPatch):
     1. Vision transformer forward method (using custom ops for data-dependent operations)
     2. Rotary embedding forward method (handling 'meta' device during export)
     3. create_causal_mask function (returns None to avoid execution issues)
+    4. WAR for multimodal export: flat image features and synthetic tensor position_ids
     """
 
     def _apply_patch(self):
@@ -115,6 +230,7 @@ class Qwen2_5_VLVisionPatch(BaseExportPatch):
         from transformers.masking_utils import create_causal_mask
         from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
             Qwen2_5_VisionTransformerPretrainedModel,
+            Qwen2_5_VLModel,
             Qwen2_5_VLRotaryEmbedding,
         )
 
@@ -123,10 +239,15 @@ class Qwen2_5_VLVisionPatch(BaseExportPatch):
         self.original_values["rope_forward"] = Qwen2_5_VLRotaryEmbedding.forward
         self.original_values["create_causal_mask"] = create_causal_mask
         self.original_values["qwen_create_causal_mask"] = qwen_modeling.create_causal_mask
+        # Store originals for model-level methods
+        self.original_values["model_get_image_features"] = Qwen2_5_VLModel.get_image_features
+        self.original_values["model_forward"] = Qwen2_5_VLModel.forward
 
         # Apply patches
         Qwen2_5_VisionTransformerPretrainedModel.forward = _patched_vision_forward
         Qwen2_5_VLRotaryEmbedding.forward = _patched_rope_forward
+        Qwen2_5_VLModel.get_image_features = _patched_get_image_features_flat
+        Qwen2_5_VLModel.forward = _patched_model_forward_export_war
 
         # Patch the create_causal_mask function in both the masking_utils module
         # and the locally imported reference in the qwen2_5_vl modeling module
@@ -139,12 +260,15 @@ class Qwen2_5_VLVisionPatch(BaseExportPatch):
         import transformers.models.qwen2_5_vl.modeling_qwen2_5_vl as qwen_modeling
         from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
             Qwen2_5_VisionTransformerPretrainedModel,
+            Qwen2_5_VLModel,
             Qwen2_5_VLRotaryEmbedding,
         )
 
         # Restore original methods
         Qwen2_5_VisionTransformerPretrainedModel.forward = self.original_values["vision_forward"]
         Qwen2_5_VLRotaryEmbedding.forward = self.original_values["rope_forward"]
+        Qwen2_5_VLModel.get_image_features = self.original_values["model_get_image_features"]
+        Qwen2_5_VLModel.forward = self.original_values["model_forward"]
 
         # Restore original create_causal_mask function in both locations
         import transformers.masking_utils

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -68,6 +68,8 @@ class InferenceOptimizer:
         ############################################################################################
         # RUN PATTERN MATCHER TRANSFORMATIONS TO STANDARDIZE GRAPH REPRESENTATION
         ############################################################################################
+        # Create both forward and backward visualizations of the initial graph
+        # visualize_model(egm, filename="initial_graph.svg", max_nodes=1000)
 
         # Match MoE pattern
         match_moe_pattern(egm)
@@ -205,6 +207,8 @@ class InferenceOptimizer:
             dynamic_shapes=cm.dynamic_shapes,
             compiler_kwargs=compiler_kwargs,
         )
+        # visualize_model(egm_compiled, max_nodes=1000)
+
         cm.info.reset()
 
         torch.cuda.empty_cache()


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

[JIRA ticket/NVBugs ID/GitHub issue][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR to support a new feature about cache manager for JIRA ticket TRTLLM-1000, it would be like:

[TRTLLM-1000][feat] Support a new feature about cache manager

Or I have a PR to fix a Llama3 accuracy issue:

[https://nvbugs/1234567][fix] Fix Llama3 accuracy issue
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
