### PR TITLE
[None][feat] Add patches for NemotronH

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/models/patches/nemotron_h.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/nemotron_h.py
@@ -1,0 +1,116 @@
+import contextlib
+import types
+from typing import Callable, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+from transformers import AutoModelForCausalLM
+
+from tensorrt_llm._torch.auto_deploy.models.patches.bamba import _bamba_mixer_torch_forward
+
+
+def rmsnorm_patch(self, hidden_states, gate=None):
+    return _rmsnorm_ref(
+        x=hidden_states,
+        weight=self.weight,
+        z=gate,
+        eps=self.variance_epsilon,
+        group_size=self.group_size,
+    )
+
+
+# Forked from:
+# https://github.com/state-spaces/mamba/blob/6b32be06d026e170b3fdaf3ae6282c5a6ff57b06/mamba_ssm/ops/triton/layernorm_gated.py
+# NOTES:
+# 1. At time of writing (09/25/2025), the nano nemotron v2 modeling code expects `mamba_ssm`
+#    to be installed so as to be able to make use of its grouped gated RMS norm operation.
+#    We therefore replace it with one that uses einops + pytorch.
+# 2. Arguments / code paths unused by nemotron H have been removed for clarity.
+def _rmsnorm_ref(x, weight, z=None, eps=1e-5, group_size=None):
+    dtype = x.dtype
+    weight = weight.float()
+    # Always gate before normalizing.
+    if z is not None:
+        x = x * F.silu(z)
+    if group_size is None:
+        rstd = 1 / torch.sqrt((x.square()).mean(dim=-1, keepdim=True) + eps)
+        out = x * rstd * weight
+    else:
+        x_group = rearrange(x, "... (g d) -> ... g d", d=group_size)
+        rstd = 1 / torch.sqrt((x_group.square()).mean(dim=-1, keepdim=True) + eps)
+        out = rearrange(x_group * rstd, "... g d -> ... (g d)") * weight
+    return out.to(dtype)
+
+
+# The original implementation looks at `cache_position[0]` to decide what to do which does not
+# play well with export. Plus, we do not want it to be updated anyway.
+def _nemotron_h_model_update_mamba_mask(self, attention_mask, cache_position):
+    return None
+
+
+def _nemotron_h_model_update_causal_mask(self, attention_mask, input_tensor, cache_position):
+    # Force attention to use causal mode without explicit masks
+    return None
+
+
+def _nemotron_h_block_forward(
+    self,
+    hidden_states,
+    cache_params=None,
+    cache_position: Optional[torch.LongTensor] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+):
+    device = hidden_states.device
+    with contextlib.ExitStack() as stack:
+        if device.type == "cuda":
+            stack.enter_context(torch.cuda.stream(torch.cuda.default_stream(device)))
+        # * Use torch.cuda.stream() to avoid NaN issues when using multiple GPUs
+        residual = hidden_states
+        hidden_states = self.norm(hidden_states.to(dtype=self.norm.weight.dtype))
+        if self.residual_in_fp32:
+            residual = residual.to(torch.float32)
+
+        if self.block_type == "mamba":
+            hidden_states = self.mixer(
+                hidden_states, cache_params=cache_params, cache_position=cache_position
+            )
+        elif self.block_type == "attention":
+            hidden_states = self.mixer(hidden_states, cache_position=cache_position)
+            hidden_states = hidden_states[0]
+        elif self.block_type == "mlp":
+            hidden_states = self.mixer(hidden_states)
+        else:
+            raise ValueError(f"Invalid block_type: {self.block_type}")
+
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+_from_config_original = AutoModelForCausalLM.from_config
+
+CUSTOM_MODULE_PATCHES: Dict[str, List[Tuple[str, Callable]]] = {
+    "MambaRMSNormGated": [("forward", rmsnorm_patch)],
+    "NemotronHMamba2Mixer": [("forward", _bamba_mixer_torch_forward)],
+    "NemotronHModel": [
+        ("_update_causal_mask", _nemotron_h_model_update_causal_mask),
+        ("_update_mamba_mask", _nemotron_h_model_update_mamba_mask),
+    ],
+    "NemotronHBlock": [("forward", _nemotron_h_block_forward)],
+}
+
+
+def get_model_from_config_patched(config, **kwargs):
+    model = _from_config_original(config, **kwargs)
+    # Patch modules
+    for _, module in model.named_modules():
+        if (module_name := type(module).__name__) in CUSTOM_MODULE_PATCHES.keys():
+            patches = CUSTOM_MODULE_PATCHES[module_name]
+            for method_name, method_patch in patches:
+                setattr(module, method_name, types.MethodType(method_patch, module))
+
+    return model
+
+
+# TODO: figure out how this can be incorporated into the export patch system
+AutoModelForCausalLM.from_config = get_model_from_config_patched

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_nemotron_h.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_nemotron_h.py
@@ -1,0 +1,191 @@
+import torch  # noqa
+import torch.export as te
+from torch.export import Dim  # noqa
+
+# import pytest
+from tensorrt_llm._torch.auto_deploy.export import apply_export_patches, torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.llm_args import AutoDeployConfig
+from tensorrt_llm._torch.auto_deploy.transformations._graph import move_to_device  # noqa
+
+# MODEL_DIR = "ibm-ai-platform/Bamba-9B-v2"
+MODEL_DIR = (
+    "/home/scratch.williamz_gpu/code/trtc/builder/hf_cache/hub/"
+    "models--nvidia--NVIDIA-Nemotron-Nano-9B-v2/snapshots/dc376c20a64208fc2cb4667e00af485eeced8ae4"
+)
+# NOTE: find example inputs with the same tokenization length to avoid seq concat.
+EXAMPLE_INPUT = "Mamba is a snake with the following properties:"
+# EXAMPLE_INPUT = "Boa is a snake with the following properties:"
+EXAMPLE_INPUT2 = "Tiger is a cat with the following properties:"
+
+
+# @pytest.mark.parametrize(
+#     "model_on_meta_during_export",
+#     [
+#         True,
+#         False,
+#     ],
+# )
+# @pytest.mark.parametrize(
+#     "export_func",
+#     [
+#         "torch_export_to_gm",
+#         "torch_export",
+#     ],
+# )
+def test_bamba_patches(
+    model_on_meta_during_export: bool = True,
+    export_func: str = "torch_export_to_gm",
+    use_cache: bool = True,
+):
+    llm_args = AutoDeployConfig(
+        **{
+            "model": MODEL_DIR,
+            "world_size": 0,
+            "runtime": "demollm",
+            "compile_backend": "torch-simple",
+            "attn_backend": "flashinfer",
+            "model_factory": "AutoModelForCausalLM",
+            "model_kwargs": {
+                "use_cache": use_cache,
+                "torch_dtype": "bfloat16",
+            },
+            "max_seq_len": 512,
+            "skip_loading_weights": False,
+        },
+    )
+
+    torch.manual_seed(0)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(0)
+
+    factory = llm_args.create_factory()
+    model = factory.build_model("meta")
+    tokenizer = factory.init_tokenizer()
+
+    # 1. Export wants min batch size of 2 (to avoid specialization during export).
+    # 2. Can't get `padding` / `truncation` to work without other steps so just use the same prompt
+    #    twice in order for the tokenizer not to complain when creating the tensor.
+    message = [EXAMPLE_INPUT] * 2
+    inputs = tokenizer(message, return_tensors="pt", return_token_type_ids=False).to("cuda")
+
+    input_ids = inputs["input_ids"]
+    position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).repeat(
+        input_ids.shape[0], 1
+    )
+    dynamic_shapes = (
+        {0: Dim("batch_size", min=0, max=8), 1: Dim("seq_len", min=0, max=512)},
+        {
+            0: Dim("batch_size", min=0, max=8),
+            1: Dim("seq_len", min=0, max=512),
+        },
+    )
+
+    def _run_torch_export_to_gm():
+        return torch_export_to_gm(
+            model,
+            # args=(input_ids, position_ids),
+            args=tuple(),
+            kwargs={"input_ids": input_ids, "position_ids": position_ids},
+            dynamic_shapes=dynamic_shapes,
+            patch_list=[
+                "bamba",
+                # For "unsupported scalarType".
+                "autocast_noop",
+            ],
+        )
+
+    def _run_torch_export():
+        with apply_export_patches(patch_list=["bamba", "autocast_noop"]):
+            with torch.inference_mode():
+                ep = te.export(
+                    model,
+                    # args=(input_ids, position_ids),
+                    args=tuple(),
+                    kwargs={"input_ids": input_ids, "position_ids": position_ids},
+                    dynamic_shapes=dynamic_shapes,
+                    strict=False,
+                )
+            egm = ep.module()
+        return egm
+
+    def _run_export():
+        if export_func == "torch_export_to_gm":
+            return _run_torch_export_to_gm()
+        else:
+            return _run_torch_export()
+
+    if model_on_meta_during_export:
+        gm = _run_export()
+        factory.load_or_random_init(gm, device="cuda")
+        move_to_device(gm, "cuda")
+
+    factory.load_or_random_init(model, device="cuda")
+
+    # _verify_generation(factory, model, tokenizer)
+    # return
+
+    print("====== EXPORTING GRAPH MODULE ======")
+    if not model_on_meta_during_export:
+        gm = _run_export()
+        move_to_device(gm, "cuda")
+
+    # gm.model.A_log = model.model.A_log
+
+    # let's do a comparison of every state dict item between the model and the gm
+    torch.testing.assert_close(model.state_dict(), gm.state_dict(), rtol=0.0, atol=0.0)
+
+    outputs_for_comparison = {}
+    with torch.inference_mode():
+        out_original = model(input_ids=input_ids, position_ids=position_ids)
+        with apply_export_patches(patch_list=["bamba"]):
+            outputs_for_comparison["patched"] = model(
+                input_ids=input_ids, position_ids=position_ids
+            )
+
+    with torch.inference_mode():
+        outputs_for_comparison["gm"] = gm(input_ids=input_ids, position_ids=position_ids)
+
+    atol, rtol = 1e-5, 1e-5
+    for comp, outs in outputs_for_comparison.items():
+        print(f"====== COMPARISON ({comp}) ======")
+        try:
+            torch.testing.assert_close(
+                outs,
+                out_original,
+                rtol=rtol,
+                atol=atol,
+            )
+            print("Passed!")
+        except AssertionError as e:
+            print(e)
+            diff = torch.abs(outs.logits - out_original.logits)
+            print(f"abs diff: {diff}")
+            print(f"average diff: {diff.mean()}")
+            print(f"{comp=}")
+
+
+def _verify_generation(factory, model, tokenizer):
+    print("====== WITHOUT PATCH ======")
+    _generate(tokenizer, model)
+    with apply_export_patches(patch_list=["bamba"]):
+        print("====== WITH PATCH ======")
+        _generate(tokenizer, model)
+
+
+def _generate(tokenizer, model):
+    messages = [
+        EXAMPLE_INPUT,
+        EXAMPLE_INPUT2,
+    ]
+    for msg in messages:
+        num_tokens = tokenizer(
+            msg, return_tensors="pt", return_token_type_ids=False
+        ).input_ids.shape[1]
+        print(f"{msg=}, {num_tokens=}")
+    inputs = tokenizer(messages, return_tensors="pt", return_token_type_ids=False).to(model.device)
+    response = model.generate(**inputs, max_new_tokens=64)
+    print("\n".join(tokenizer.batch_decode(response, skip_special_tokens=True)))
+
+
+if __name__ == "__main__":
+    test_bamba_patches()


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

NOTE: the below diff needs to be edited into the `modeling_nemotron_h.py` in the HF repo.

```diff
--- a/modeling_nemotron_h.py
+++ b/modeling_nemotron_h.py
@@ -58,11 +58,11 @@
 else:
     mamba_chunk_scan_combined, mamba_split_conv1d_scan_combined, selective_state_update = None, None, None

-try:
-    #from mamba_ssm.ops.triton.layernorm_gated import RMSNorm as RMSNormGated
-    from mamba_ssm.ops.triton.layernorm_gated import rmsnorm_fn
-except ImportError:
-    raise ImportError("mamba-ssm is required by the Mamba model but cannot be imported")
+# try:
+#     #from mamba_ssm.ops.triton.layernorm_gated import RMSNorm as RMSNormGated
+#     from mamba_ssm.ops.triton.layernorm_gated import rmsnorm_fn
+# except ImportError:
+#     raise ImportError("mamba-ssm is required by the Mamba model but cannot be imported")

 if is_causal_conv1d_available():
     from causal_conv1d import causal_conv1d_fn, causal_conv1d_update
```

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
