### PR TITLE
[None][perf] AutoDeploy: fast-path Python-list staging in nest_sequences

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -241,16 +241,22 @@ class InputBuffer:
         if fill_value is not None:
             host_view.fill_(fill_value)
 
-        # convert to tensor via numpy (numpy is ~2-3x faster than torch.tensor for large lists)
-        if not isinstance(data, torch.Tensor):
-            data = _list_to_tensor(data, dtype)
-
-        length = data.numel()
-        assert length <= numel, f"Data too large for buffer '{name}': {length} > {numel}"
-        # Use numpy for the memcpy into pinned memory — avoids torch dispatcher overhead
-        dst = host_view[:length].numpy()
-        src = (data if data.dtype == dtype else data.to(dtype)).numpy()
-        np.copyto(dst, src)
+        if isinstance(data, torch.Tensor):
+            length = data.numel()
+            assert length <= numel, f"Data too large for buffer '{name}': {length} > {numel}"
+            # Use numpy for the memcpy into pinned memory — avoids torch dispatcher overhead
+            dst = host_view[:length].numpy()
+            src = (data if data.dtype == dtype else data.to(dtype)).numpy()
+            np.copyto(dst, src)
+        else:
+            # Fast path for Python lists/sequences: assign directly into the pinned host
+            # numpy view. numpy casts the sequence to the buffer dtype in a single pass,
+            # skipping the np.array -> torch.from_numpy (_list_to_tensor) -> two .numpy()
+            # round-trip that dominated tiny per-arg decode staging (input_ids, cu_seqlen,
+            # input_pos arrive as small lists every step at low concurrency).
+            length = len(data)
+            assert length <= numel, f"Data too large for buffer '{name}': {length} > {numel}"
+            host_view[:length].numpy()[:] = data
 
         self._current_lengths[name] = length
         return length


### PR DESCRIPTION
## Summary
Optimizes the per-arg decode input staging in AutoDeploy's `InputBuffer.stage` (the `nest_sequences` host path), which py-spy profiling identified as the dominant host hotspot at low concurrency (`_prepare_inputs` ~23–30% of the decode loop, almost all in per-arg staging).

Python-list inputs (`input_ids`, `cu_seqlen`, `input_pos`, `slot_idx` — staged every decode step) previously went through `_list_to_tensor` (`np.array` → `torch.from_numpy`) and were then unwrapped again with two `.numpy()` calls + `np.copyto`. This change assigns the list directly into the pinned host numpy view (`host_view[:n].numpy()[:] = data`), letting numpy cast to the buffer dtype in a single pass. The `torch.Tensor` staging path is unchanged.

## Perf
Microbench (tiny c=1 decode args, 4 list args/step): **1.79× faster** staging (35.3 → 19.8 µs/step). Output bit-identical to the previous path.

## Test
- Microbench asserts bit-identical host-buffer contents vs the previous path for both list and tensor inputs.
- End-to-end WS=1 greedy decode (Nemotron-3-Nano NVFP4): deterministic, unchanged output, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)