### PR TITLE
[None][test] Use full-warp hidden_size (256) in allreduce CI smoke test

### DIFF
--- a/tests/unittest/auto_deploy/multigpu/smoke/test_ad_allreduce_strategies.py
+++ b/tests/unittest/auto_deploy/multigpu/smoke/test_ad_allreduce_strategies.py
@@ -217,7 +217,20 @@ def test_allreduce_strategies(llm_root, shared_dataset, allreduce_strategy):  # 
     TEST_TIMEOUT_SECONDS = 300
 
     model_name = "meta-llama/Meta-Llama-3.1-8B-Instruct"
-    config = get_small_model_config(model_name)
+    # Override hidden_size to a multiple of one warp's worth of 128-bit accesses (32 threads *
+    # 8 fp16 elements/access = 256) so the fused all-reduce/RMSNorm kernel never launches a
+    # partial-warp block. This isolates whether CI failures are specific to the partial-warp
+    # code path or are unrelated infra flakiness that also affects the full-warp path.
+    config = get_small_model_config(
+        model_name,
+        model_kwargs={
+            "num_hidden_layers": 1,
+            "hidden_size": 256,
+            "intermediate_size": 256,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+        },
+    )
     tp_size = 2
     max_batch_size = 256
     max_num_tokens = 8192


### PR DESCRIPTION
## Description

Stacked on agent/fix-ad-allreduce-ci (upstream NVIDIA#16111). The only change: overrides the AutoDeploy allreduce-strategy smoke test's tiny model `hidden_size` from 64 to 256, so the fused all-reduce/RMSNorm kernel's `blockReduceSum` always launches exactly one full warp (32 threads) instead of the partial-warp (8-thread) block.

## Motivation

Diagnostic follow-up to NVIDIA#16111's CI investigation. Two `DGX_B200-4_GPUs-AutoDeploy-1` runs of NVIDIA#16111 failed with `CUBLAS_STATUS_EXECUTION_FAILED` in an unrelated cuBLAS GEMM (`torch_linear_simple`), on the same node (`nsc-svg-slurm-1-gpu-120`), at a different allreduce strategy each time - evidence pointing at node-level flakiness rather than the kernel fix itself. The same diff, opened separately as NVIDIA#16333 (against `main`), passed cleanly on a different node (`nsc-svg-slurm-1-gpu-135`), all 6 strategies.

This PR isolates the single-file test diff on its own, stacked directly on the fix branch, for a clean before/after comparison.

## Test Coverage

Same `test_allreduce_strategies` smoke test, all 6 strategies, `hidden_size=256` instead of 64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)